### PR TITLE
i2c.c: rename "clock" => "scl" (+ modSsd1306.c). Fixes gh-14

### DIFF
--- a/examples/drivers/BMP180/manifest.json
+++ b/examples/drivers/BMP180/manifest.json
@@ -1,0 +1,27 @@
+{
+	"include": "$(MODDABLE)/examples/manifest_base.json",
+	"modules": {
+		"*": [
+			"./main"
+		],
+		"pins/i2c": "$(MODULES)/pins/i2c/i2c",
+		"pins/smbus": "$(MODULES)/pins/smbus/smbus",
+	},
+	"preload": [
+		"pins/i2c",
+		"pins/smbus",
+	],
+	"platforms": {
+		"esp": {
+			"modules": {
+				"pins/i2c": "$(MODULES)/pins/i2c/i2c",
+				"*": [
+					"$(MODULES)/pins/i2c/esp/*",
+				],
+			},
+			"preload": [
+				"pins/i2c",
+			]
+		},
+	}
+}

--- a/examples/drivers/HMC5883L/manifest.json
+++ b/examples/drivers/HMC5883L/manifest.json
@@ -1,0 +1,27 @@
+{
+	"include": "$(MODDABLE)/examples/manifest_base.json",
+	"modules": {
+		"*": [
+			"./main"
+		],
+		"pins/i2c": "$(MODULES)/pins/i2c/i2c",
+		"pins/smbus": "$(MODULES)/pins/smbus/smbus",
+	},
+	"preload": [
+		"pins/i2c",
+		"pins/smbus",
+	],
+	"platforms": {
+		"esp": {
+			"modules": {
+				"pins/i2c": "$(MODULES)/pins/i2c/i2c",
+				"*": [
+					"$(MODULES)/pins/i2c/esp/*",
+				],
+			},
+			"preload": [
+				"pins/i2c",
+			]
+		},
+	}
+}


### PR DESCRIPTION
Smoke tested with:

- examples/drivers/BMP180
- examples/drivers/lis3dh
- examples/drivers/mcp23008 (existing and new feature branch)
- examples/drivers/mcp23017