### PR TITLE
REPL x-cli-wi: Fix syntax error

### DIFF
--- a/examples/js/repl/win/repl.c
+++ b/examples/js/repl/win/repl.c
@@ -22,7 +22,7 @@
 #include "xsAll.h"
 #include "mc.xs.h"
 
-extern txPreparation* xsPreparation();
+extern txPreparation* xsPreparation;
 
 void fxAbort(xsMachine* the)
 {


### PR DESCRIPTION
The REPL x-cli-win has a syntax error.

```
C:\Users\rhys\Projects\moddable\examples\js\repl>mcconfig -d -m -p x-cli-win
repl.c
C:\Users\rhys\Projects\moddable\examples\js\repl\win\repl.c(25): error C2143: syntax error: missing ')' before '('
C:\Users\rhys\Projects\moddable\examples\js\repl\win\repl.c(25): error C2091: function returns function
C:\Users\rhys\Projects\moddable\examples\js\repl\win\repl.c(25): error C2059: syntax error: ')'
```

Removing `()` allows the compile