### PR TITLE
fix double config: streaming-adafruit-io

### DIFF
--- a/examples/network/services/streaming-adafruit-io/manifest.json
+++ b/examples/network/services/streaming-adafruit-io/manifest.json
@@ -8,6 +8,7 @@
 		"username": "YOUR_USERNAME_HERE",
 		"feedKey": "YOUR_FEED_KEY_HERE",
 		"AIOKey": "YOUR_AIO_KEY_HERE",
+		"sntp": "pool.ntp.org",		
 	},
 	"modules": {
 		"*": [
@@ -22,8 +23,5 @@
 		"*": [
 			"$(MODULES)/crypt/data/ca170",
 		]
-	},
-	"config": {
-		"sntp": "pool.ntp.org",
 	},
 }


### PR DESCRIPTION
The double config overwrites the adafruit io settings