### PR TITLE
Fixes path to IDF `requirements.txt`

### DIFF
--- a/documentation/Moddable SDK - Getting Started.md
+++ b/documentation/Moddable SDK - Getting Started.md
@@ -178,7 +178,7 @@ Additional getting started guides are available for the following devices:
 8. Install the required Python packages:
 
 	```
-	python -m pip install --user -r $IDF_PATH/docs/requirements.txt
+	python -m pip install --user -r $IDF_PATH/requirements.txt
 	```
 
 9. Update the `PATH` environment variable in your `~/.profile` to include the toolchain directory:
@@ -583,7 +583,7 @@ Additional getting started guides are available for the following devices:
 8. Install the required Python packages:
 
 	```
-	python -m pip install --user -r $IDF_PATH/docs/requirements.txt
+	python -m pip install --user -r $IDF_PATH/requirements.txt
 	```
 
 9. Update the `PATH` environment variable in your `~/.bashrc` to include the toolchain directory:


### PR DESCRIPTION
[Per Espressif](https://docs.espressif.com/projects/esp-idf/en/stable/get-started/#install-the-required-python-packages), the intended `requirements.txt` lives in `$IDF_PATH` and not in `IDF_PATH/docs/requirements.txt` (which is used to build the docs site using `sphinx`).