### PR TITLE
Add mcconfig -n flag that skips flashing an attached device at the end of the build

### DIFF
--- a/tools/mcconfig.js
+++ b/tools/mcconfig.js
@@ -1131,10 +1131,17 @@ export default class extends Tool {
 		file.generate(this);
 
 		if (this.make) {
-			if (this.windows)
-				this.then("nmake", "/nologo", "/f", path);
-			else
-				this.then("make", "-f", path);
+			if (this.noFlash) {
+				if (this.windows)
+					this.then("nmake", "/nologo", "/f", path, "all-noflash");
+				else
+					this.then("make", "-f", path, "all-noflash");
+			} else {
+				if (this.windows)
+					this.then("nmake", "/nologo", "/f", path);
+				else
+					this.then("make", "-f", path);
+			}
 		}
 	}
 }

--- a/tools/mcconfig/make.esp.mk
+++ b/tools/mcconfig/make.esp.mk
@@ -324,9 +324,11 @@ ESPTOOL_FLASH_OPT = \
 
 UPLOAD_TO_ESP = $(ESPTOOL) -b $(UPLOAD_SPEED) -p $(UPLOAD_PORT) write_flash $(ESPTOOL_FLASH_OPT)
 
-.PHONY: all
+.PHONY: all all-noflash
 
-all: $(LAUNCH)
+all: all-noflash
+
+all-noflash: $(LAUNCH)
 
 debuglin: $(LIB_DIR) $(BIN_DIR)/main.bin
 	$(shell pkill serial2xsbug)

--- a/tools/mcconfig/make.esp32.mk
+++ b/tools/mcconfig/make.esp32.mk
@@ -235,7 +235,7 @@ MEM_USAGE = \
 
 VPATH += $(SDK_DIRS) $(XS_DIRS)
 
-.PHONY: all	
+.PHONY: all all-noflash flash
 
 PARTITIONS_FILE ?= $(PROJ_DIR_TEMPLATE)/partitions.csv
 
@@ -270,7 +270,9 @@ SDKCONFIG_H=$(IDF_BUILD_DIR)/include/sdkconfig.h
 
 .NOTPARALLEL: $(SDKCONFIG_H)
 
-all: projDir $(BLE) $(SDKCONFIG_H) $(LIB_DIR) $(BIN_DIR)/xs_esp32.a
+all: all-noflash flash
+
+all-noflash: projDir $(BLE) $(SDKCONFIG_H) $(LIB_DIR) $(BIN_DIR)/xs_esp32.a
 	$(KILL_SERIAL_2_XSBUG)
 	$(DO_XSBUG)
 	-@rm $(IDF_BUILD_DIR)/xs_esp32.elf 2>/dev/null
@@ -278,6 +280,8 @@ all: projDir $(BLE) $(SDKCONFIG_H) $(LIB_DIR) $(BIN_DIR)/xs_esp32.a
 	-@mkdir -p $(IDF_BUILD_DIR) 2>/dev/null
 	cp $(BIN_DIR)/xs_esp32.a $(IDF_BUILD_DIR)/.
 	touch $(PROJ_DIR)/main/main.c
+
+flash :
 	-cd $(PROJ_DIR) ; IDF_BUILD_DIR=$(IDF_BUILD_DIR) DEBUG=$(DEBUG) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE) DEBUGGER_SPEED=$(DEBUGGER_SPEED) make flash && $(DO_LAUNCH)
 	-cp $(IDF_BUILD_DIR)/xs_esp32.map $(BIN_DIR)
 	-cp $(IDF_BUILD_DIR)/xs_esp32.bin $(BIN_DIR)

--- a/tools/mcconfig/make.esp32.mk
+++ b/tools/mcconfig/make.esp32.mk
@@ -292,7 +292,7 @@ all-noflash: projDir $(BLE) $(SDKCONFIG_H) $(LIB_DIR) $(BIN_DIR)/xs_esp32.a
 	-@mkdir -p $(IDF_BUILD_DIR) 2>/dev/null
 	cp $(BIN_DIR)/xs_esp32.a $(IDF_BUILD_DIR)/.
 	touch $(PROJ_DIR)/main/main.c
-	-cd $(PROJ_DIR) ; IDF_BUILD_DIR=$(IDF_BUILD_DIR) DEBUG=$(DEBUG) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE) DEBUGGER_SPEED=$(DEBUGGER_SPEED) make flash 'ESPTOOLPY_WRITE_FLASH=echo Skipping flashing #'
+	-cd $(PROJ_DIR) ; IDF_BUILD_DIR=$(IDF_BUILD_DIR) DEBUG=$(DEBUG) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE) DEBUGGER_SPEED=$(DEBUGGER_SPEED) make flash 'ESPTOOLPY_WRITE_FLASH=python ${MODDABLE}/tools/skip-flash.py'
 	-cp $(IDF_BUILD_DIR)/xs_esp32.map $(BIN_DIR)
 	-cp $(IDF_BUILD_DIR)/xs_esp32.bin $(BIN_DIR)
 	-cp $(IDF_BUILD_DIR)/partitions.bin $(BIN_DIR)

--- a/tools/mcconfig/make.lin.mk
+++ b/tools/mcconfig/make.lin.mk
@@ -137,9 +137,11 @@ XSL = $(MODDABLE_TOOLS_DIR)/xsl
 
 VPATH += $(XS_DIRECTORIES)
 
-.PHONY: all	
+.PHONY: all	all-noflash
 	
-all: $(LIB_DIR) $(BIN_DIR)/mc.so
+all: all-noflash
+
+all-noflash : $(LIB_DIR) $(BIN_DIR)/mc.so
 	$(shell nohup $(SIMULATOR) $(BIN_DIR)/mc.so > /dev/null 2>&1 &)
 	
 $(LIB_DIR):

--- a/tools/mcconfig/make.lin.mk
+++ b/tools/mcconfig/make.lin.mk
@@ -138,12 +138,12 @@ XSL = $(MODDABLE_TOOLS_DIR)/xsl
 VPATH += $(XS_DIRECTORIES)
 
 .PHONY: all	all-noflash
-	
+
 all: all-noflash
 
 all-noflash : $(LIB_DIR) $(BIN_DIR)/mc.so
 	$(shell nohup $(SIMULATOR) $(BIN_DIR)/mc.so > /dev/null 2>&1 &)
-	
+
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)
 	

--- a/tools/mcconfig/make.mac.mk
+++ b/tools/mcconfig/make.mac.mk
@@ -133,11 +133,13 @@ XSL = $(BUILD_DIR)/bin/mac/release/xsl
 
 VPATH += $(XS_DIRECTORIES)
 
-.PHONY: all	
-	
-all: $(LIB_DIR) $(BIN_DIR)/mc.so
+.PHONY: all	all-noflash
+
+all: all-noflash
+
+all-noflash: $(LIB_DIR) $(BIN_DIR)/mc.so
 	open -a $(SIMULATOR) $(BIN_DIR)/mc.so
-	
+
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)
 	

--- a/tools/mcconfig/make.x-cli-mac.mk
+++ b/tools/mcconfig/make.x-cli-mac.mk
@@ -125,9 +125,11 @@ XSL = $(BUILD_DIR)/bin/mac/debug/xsl
 	
 VPATH += $(XS_DIRECTORIES)
 
-.PHONY: all	
-	
-all: $(LIB_DIR) $(BIN_DIR)/$(NAME)
+.PHONY: all	all-noflash
+
+all: all-noflash
+
+all-noflash: $(LIB_DIR) $(BIN_DIR)/$(NAME)
 	
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)

--- a/tools/mcconfig/make.x-cli-mac.mk
+++ b/tools/mcconfig/make.x-cli-mac.mk
@@ -130,7 +130,7 @@ VPATH += $(XS_DIRECTORIES)
 all: all-noflash
 
 all-noflash: $(LIB_DIR) $(BIN_DIR)/$(NAME)
-	
+
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)
 

--- a/tools/mcconfig/make.x-lin.mk
+++ b/tools/mcconfig/make.x-lin.mk
@@ -135,9 +135,11 @@ endif
 
 VPATH += $(XS_DIRECTORIES)
 
-.PHONY: all	
+.PHONY: all	all-noflash
 
-all: $(LIB_DIR) $(BIN_DIR)/$(NAME)
+all: all-noflash
+
+all-noflash: $(LIB_DIR) $(BIN_DIR)/$(NAME)
 
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)

--- a/tools/mcconfig/make.x-mac.mk
+++ b/tools/mcconfig/make.x-mac.mk
@@ -127,11 +127,11 @@ XSL = $(BUILD_DIR)/bin/mac/debug/xsl
 VPATH += $(XS_DIRECTORIES)
 
 .PHONY: all	all-noflash
-	
+
 all: all-noflash
 
 all-noflash: $(LIB_DIR) $(BIN_DIR)/Info.plist $(BIN_DIR)/MacOS/main $(RESOURCES_DIR)/main.icns $(RESOURCES)
-	
+
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)
 

--- a/tools/mcconfig/make.x-mac.mk
+++ b/tools/mcconfig/make.x-mac.mk
@@ -126,9 +126,11 @@ XSL = $(BUILD_DIR)/bin/mac/debug/xsl
 	
 VPATH += $(XS_DIRECTORIES)
 
-.PHONY: all	
+.PHONY: all	all-noflash
 	
-all: $(LIB_DIR) $(BIN_DIR)/Info.plist $(BIN_DIR)/MacOS/main $(RESOURCES_DIR)/main.icns $(RESOURCES)
+all: all-noflash
+
+all-noflash: $(LIB_DIR) $(BIN_DIR)/Info.plist $(BIN_DIR)/MacOS/main $(RESOURCES_DIR)/main.icns $(RESOURCES)
 	
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)

--- a/tools/mcconfig/nmake.esp.mk
+++ b/tools/mcconfig/nmake.esp.mk
@@ -330,12 +330,14 @@ ESPTOOL_FLASH_OPT = \
 
 UPLOAD_TO_ESP = $(ESPTOOL) -b $(UPLOAD_SPEED) -p $(UPLOAD_PORT) write_flash $(ESPTOOL_FLASH_OPT)
 
-.PHONY: all	
+.PHONY: all	all-noflash
 
 APP_ARCHIVE = $(BIN_DIR)\libxsar.a
 LIB_ARCHIVE = $(LIB_DIR)\libxslib.a
 
-all: $(LAUNCH)
+all: all-noflash
+
+all-noflash: $(LAUNCH)
 
 debug: $(LIB_DIR) $(LIB_ARCHIVE) $(APP_ARCHIVE) $(BIN_DIR)\main.bin
 	-tasklist /nh /fi "imagename eq serial2xsbug.exe" | (find /i "serial2xsbug.exe" > nul) && taskkill /f /t /im "serial2xsbug.exe" >nul 2>&1

--- a/tools/mcconfig/nmake.esp32.mk
+++ b/tools/mcconfig/nmake.esp32.mk
@@ -283,7 +283,7 @@ debug-noflash: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
 	if not exist $(IDF_BUILD_DIR) mkdir $(IDF_BUILD_DIR)
 	copy $(BIN_DIR)\xs_esp32.a $(IDF_BUILD_DIR)\.
 	set HOME=$(PROJ_DIR)
-	$(MSYS32_BASE)\msys2_shell.cmd -mingw32 -c "echo Building xs_esp32.elf...; touch ./main/main.c; DEBUG=1 IDF_BUILD_DIR=$(IDF_BUILD_DIR_MINGW) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE_MINGW) DEBUGGER_SPEED=$(DEBUGGER_SPEED) make flash 'ESPTOOLPY_WRITE_FLASH=echo Skipping flashing #'; cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.map $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/partitions.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/bootloader/bootloader.bin $(BIN_DIR_MINGW); echo Launching app...; echo -e '\nType Ctrl-C after debugging app to close this window'; $(SERIAL2XSBUG) $(UPLOAD_PORT) $(DEBUGGER_SPEED) 8N1 | more"
+	$(MSYS32_BASE)\msys2_shell.cmd -mingw32 -c "echo Building xs_esp32.elf...; touch ./main/main.c; DEBUG=1 IDF_BUILD_DIR=$(IDF_BUILD_DIR_MINGW) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE_MINGW) DEBUGGER_SPEED=$(DEBUGGER_SPEED) make flash 'ESPTOOLPY_WRITE_FLASH=python ${MODDABLE}/tools/skip-flash.py'; cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.map $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/partitions.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/bootloader/bootloader.bin $(BIN_DIR_MINGW); echo Launching app...; echo -e '\nType Ctrl-C after debugging app to close this window'; $(SERIAL2XSBUG) $(UPLOAD_PORT) $(DEBUGGER_SPEED) 8N1 | more"
 
 release: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
 	if exist $(IDF_BUILD_DIR)\xs_esp32.elf del $(IDF_BUILD_DIR)\xs_esp32.elf
@@ -297,7 +297,7 @@ release-noflash: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
 	if not exist $(IDF_BUILD_DIR) mkdir $(IDF_BUILD_DIR)
 	copy $(BIN_DIR)\xs_esp32.a $(IDF_BUILD_DIR)\.
 	set HOME=$(PROJ_DIR)
-	$(MSYS32_BASE)\msys2_shell.cmd -mingw32 -c "echo Building xs_esp32.elf...; touch ./main/main.c; DEBUG=0 IDF_BUILD_DIR=$(IDF_BUILD_DIR_MINGW) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE_MINGW) make flash 'ESPTOOLPY_WRITE_FLASH=echo Skipping flashing #'; cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.map $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/partitions.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/bootloader/bootloader.bin $(BIN_DIR_MINGW); make monitor;"
+	$(MSYS32_BASE)\msys2_shell.cmd -mingw32 -c "echo Building xs_esp32.elf...; touch ./main/main.c; DEBUG=0 IDF_BUILD_DIR=$(IDF_BUILD_DIR_MINGW) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE_MINGW) make flash 'ESPTOOLPY_WRITE_FLASH=python ${MODDABLE}/tools/skip-flash.py'; cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.map $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/partitions.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/bootloader/bootloader.bin $(BIN_DIR_MINGW); make monitor;"
 
 $(SDKCONFIG_H): $(SDKCONFIG_FILE)
 	if exist $(TMP_DIR)\_s.tmp del $(TMP_DIR)\_s.tmp

--- a/tools/mcconfig/nmake.esp32.mk
+++ b/tools/mcconfig/nmake.esp32.mk
@@ -261,9 +261,11 @@ PROJ_DIR_FILES = \
 	$(PROJ_DIR)\partitions.csv \
 	$(PROJ_DIR)\Makefile
 
-.PHONY: all
+.PHONY: all all-noflash debug-flash release-flash
 
-all: projDir $(BLE) $(SDKCONFIG_H) $(LAUNCH)
+all: projDir $(BLE) $(SDKCONFIG_H) $(LAUNCH) $(LAUNCH)-flash
+
+all-noflash: projDir $(BLE) $(SDKCONFIG_H) $(LAUNCH)
 
 debug: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
 	-tasklist /nh /fi "imagename eq serial2xsbug.exe" | (find /i "serial2xsbug.exe" > nul) && taskkill /f /t /im "serial2xsbug.exe" >nul 2>&1
@@ -271,6 +273,8 @@ debug: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
 	if exist $(IDF_BUILD_DIR)\xs_esp32.elf del $(IDF_BUILD_DIR)\xs_esp32.elf
 	if not exist $(IDF_BUILD_DIR) mkdir $(IDF_BUILD_DIR)
 	copy $(BIN_DIR)\xs_esp32.a $(IDF_BUILD_DIR)\.
+
+debug-flash:
 	set HOME=$(PROJ_DIR)
 	$(MSYS32_BASE)\msys2_shell.cmd -mingw32 -c "echo Building xs_esp32.elf...; touch ./main/main.c; DEBUG=1 IDF_BUILD_DIR=$(IDF_BUILD_DIR_MINGW) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE_MINGW) DEBUGGER_SPEED=$(DEBUGGER_SPEED) make flash; cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.map $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/partitions.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/bootloader/bootloader.bin $(BIN_DIR_MINGW); echo Launching app...; echo -e '\nType Ctrl-C after debugging app to close this window'; $(SERIAL2XSBUG) $(UPLOAD_PORT) $(DEBUGGER_SPEED) 8N1 | more"
 
@@ -278,6 +282,8 @@ release: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
 	if exist $(IDF_BUILD_DIR)\xs_esp32.elf del $(IDF_BUILD_DIR)\xs_esp32.elf
 	if not exist $(IDF_BUILD_DIR) mkdir $(IDF_BUILD_DIR)
 	copy $(BIN_DIR)\xs_esp32.a $(IDF_BUILD_DIR)\.
+
+release-flash:
 	set HOME=$(PROJ_DIR)
 	$(MSYS32_BASE)\msys2_shell.cmd -mingw32 -c "echo Building xs_esp32.elf...; touch ./main/main.c; DEBUG=0 IDF_BUILD_DIR=$(IDF_BUILD_DIR_MINGW) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE_MINGW) make flash; cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.map $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/partitions.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/bootloader/bootloader.bin $(BIN_DIR_MINGW); make monitor;"
 

--- a/tools/mcconfig/nmake.esp32.mk
+++ b/tools/mcconfig/nmake.esp32.mk
@@ -261,11 +261,11 @@ PROJ_DIR_FILES = \
 	$(PROJ_DIR)\partitions.csv \
 	$(PROJ_DIR)\Makefile
 
-.PHONY: all all-noflash debug-flash release-flash
+.PHONY: all all-noflash debug-noflash release-noflash
 
-all: projDir $(BLE) $(SDKCONFIG_H) $(LAUNCH) $(LAUNCH)-flash
+all: projDir $(BLE) $(SDKCONFIG_H) $(LAUNCH)
 
-all-noflash: projDir $(BLE) $(SDKCONFIG_H) $(LAUNCH)
+all-noflash: projDir $(BLE) $(SDKCONFIG_H) $(LAUNCH)-noflash
 
 debug: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
 	-tasklist /nh /fi "imagename eq serial2xsbug.exe" | (find /i "serial2xsbug.exe" > nul) && taskkill /f /t /im "serial2xsbug.exe" >nul 2>&1
@@ -273,19 +273,31 @@ debug: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
 	if exist $(IDF_BUILD_DIR)\xs_esp32.elf del $(IDF_BUILD_DIR)\xs_esp32.elf
 	if not exist $(IDF_BUILD_DIR) mkdir $(IDF_BUILD_DIR)
 	copy $(BIN_DIR)\xs_esp32.a $(IDF_BUILD_DIR)\.
-
-debug-flash:
 	set HOME=$(PROJ_DIR)
 	$(MSYS32_BASE)\msys2_shell.cmd -mingw32 -c "echo Building xs_esp32.elf...; touch ./main/main.c; DEBUG=1 IDF_BUILD_DIR=$(IDF_BUILD_DIR_MINGW) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE_MINGW) DEBUGGER_SPEED=$(DEBUGGER_SPEED) make flash; cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.map $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/partitions.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/bootloader/bootloader.bin $(BIN_DIR_MINGW); echo Launching app...; echo -e '\nType Ctrl-C after debugging app to close this window'; $(SERIAL2XSBUG) $(UPLOAD_PORT) $(DEBUGGER_SPEED) 8N1 | more"
+
+debug-noflash: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
+	-tasklist /nh /fi "imagename eq serial2xsbug.exe" | (find /i "serial2xsbug.exe" > nul) && taskkill /f /t /im "serial2xsbug.exe" >nul 2>&1
+	tasklist /nh /fi "imagename eq xsbug.exe" | find /i "xsbug.exe" > nul || (start $(BUILD_DIR)\bin\win\release\xsbug.exe)
+	if exist $(IDF_BUILD_DIR)\xs_esp32.elf del $(IDF_BUILD_DIR)\xs_esp32.elf
+	if not exist $(IDF_BUILD_DIR) mkdir $(IDF_BUILD_DIR)
+	copy $(BIN_DIR)\xs_esp32.a $(IDF_BUILD_DIR)\.
+	set HOME=$(PROJ_DIR)
+	$(MSYS32_BASE)\msys2_shell.cmd -mingw32 -c "echo Building xs_esp32.elf...; touch ./main/main.c; DEBUG=1 IDF_BUILD_DIR=$(IDF_BUILD_DIR_MINGW) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE_MINGW) DEBUGGER_SPEED=$(DEBUGGER_SPEED) make flash 'ESPTOOLPY_WRITE_FLASH=echo Skipping flashing #'; cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.map $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/partitions.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/bootloader/bootloader.bin $(BIN_DIR_MINGW); echo Launching app...; echo -e '\nType Ctrl-C after debugging app to close this window'; $(SERIAL2XSBUG) $(UPLOAD_PORT) $(DEBUGGER_SPEED) 8N1 | more"
 
 release: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
 	if exist $(IDF_BUILD_DIR)\xs_esp32.elf del $(IDF_BUILD_DIR)\xs_esp32.elf
 	if not exist $(IDF_BUILD_DIR) mkdir $(IDF_BUILD_DIR)
 	copy $(BIN_DIR)\xs_esp32.a $(IDF_BUILD_DIR)\.
-
-release-flash:
 	set HOME=$(PROJ_DIR)
 	$(MSYS32_BASE)\msys2_shell.cmd -mingw32 -c "echo Building xs_esp32.elf...; touch ./main/main.c; DEBUG=0 IDF_BUILD_DIR=$(IDF_BUILD_DIR_MINGW) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE_MINGW) make flash; cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.map $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/partitions.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/bootloader/bootloader.bin $(BIN_DIR_MINGW); make monitor;"
+
+release-noflash: $(LIB_DIR) $(BIN_DIR)\xs_esp32.a
+	if exist $(IDF_BUILD_DIR)\xs_esp32.elf del $(IDF_BUILD_DIR)\xs_esp32.elf
+	if not exist $(IDF_BUILD_DIR) mkdir $(IDF_BUILD_DIR)
+	copy $(BIN_DIR)\xs_esp32.a $(IDF_BUILD_DIR)\.
+	set HOME=$(PROJ_DIR)
+	$(MSYS32_BASE)\msys2_shell.cmd -mingw32 -c "echo Building xs_esp32.elf...; touch ./main/main.c; DEBUG=0 IDF_BUILD_DIR=$(IDF_BUILD_DIR_MINGW) SDKCONFIG_DEFAULTS=$(SDKCONFIG_FILE_MINGW) make flash 'ESPTOOLPY_WRITE_FLASH=echo Skipping flashing #'; cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.map $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/xs_esp32.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/partitions.bin $(BIN_DIR_MINGW); cp $(IDF_BUILD_DIR_MINGW)/bootloader/bootloader.bin $(BIN_DIR_MINGW); make monitor;"
 
 $(SDKCONFIG_H): $(SDKCONFIG_FILE)
 	if exist $(TMP_DIR)\_s.tmp del $(TMP_DIR)\_s.tmp

--- a/tools/mcconfig/nmake.win.mk
+++ b/tools/mcconfig/nmake.win.mk
@@ -156,7 +156,9 @@ XSC = $(BUILD_DIR)\bin\win\debug\xsc
 XSID = $(BUILD_DIR)\bin\win\debug\xsid
 XSL = $(BUILD_DIR)\bin\win\debug\xsl
 	
-all: $(LIB_DIR) $(BIN_DIR)\mc.dll
+all: all-noflash
+
+all-noflash: $(LIB_DIR) $(BIN_DIR)\mc.dll
 	start $(SIMULATOR) $(BIN_DIR)\mc.dll
 
 $(LIB_DIR) :

--- a/tools/mcconfig/nmake.win.mk
+++ b/tools/mcconfig/nmake.win.mk
@@ -155,7 +155,7 @@ WAV2MAUD = $(BUILD_DIR)\bin\win\debug\wav2maud
 XSC = $(BUILD_DIR)\bin\win\debug\xsc
 XSID = $(BUILD_DIR)\bin\win\debug\xsid
 XSL = $(BUILD_DIR)\bin\win\debug\xsl
-	
+
 all: all-noflash
 
 all-noflash: $(LIB_DIR) $(BIN_DIR)\mc.dll

--- a/tools/mcconfig/nmake.x-cli-win.mk
+++ b/tools/mcconfig/nmake.x-cli-win.mk
@@ -151,7 +151,7 @@ MCREZ = $(BUILD_DIR)\bin\win\debug\mcrez
 XSC = $(BUILD_DIR)\bin\win\debug\xsc
 XSID = $(BUILD_DIR)\bin\win\debug\xsid
 XSL = $(BUILD_DIR)\bin\win\debug\xsl
-	
+
 all: all-noflash
 
 all-noflash: $(LIB_DIR) $(BIN_DIR)\$(NAME).exe

--- a/tools/mcconfig/nmake.x-cli-win.mk
+++ b/tools/mcconfig/nmake.x-cli-win.mk
@@ -152,7 +152,9 @@ XSC = $(BUILD_DIR)\bin\win\debug\xsc
 XSID = $(BUILD_DIR)\bin\win\debug\xsid
 XSL = $(BUILD_DIR)\bin\win\debug\xsl
 	
-all: $(LIB_DIR) $(BIN_DIR)\$(NAME).exe 
+all: all-noflash
+
+all-noflash: $(LIB_DIR) $(BIN_DIR)\$(NAME).exe
 
 $(LIB_DIR) :
 	if not exist $(LIB_DIR)\$(NULL) mkdir $(LIB_DIR)

--- a/tools/mcconfig/nmake.x-win.mk
+++ b/tools/mcconfig/nmake.x-win.mk
@@ -152,7 +152,7 @@ MCREZ = $(BUILD_DIR)\bin\win\debug\mcrez
 XSC = $(BUILD_DIR)\bin\win\debug\xsc
 XSID = $(BUILD_DIR)\bin\win\debug\xsid
 XSL = $(BUILD_DIR)\bin\win\debug\xsl
-	
+
 all: all-noflash
 
 all-noflash: $(LIB_DIR) $(BIN_DIR)\$(NAME).exe 

--- a/tools/mcconfig/nmake.x-win.mk
+++ b/tools/mcconfig/nmake.x-win.mk
@@ -153,7 +153,9 @@ XSC = $(BUILD_DIR)\bin\win\debug\xsc
 XSID = $(BUILD_DIR)\bin\win\debug\xsid
 XSL = $(BUILD_DIR)\bin\win\debug\xsl
 	
-all: $(LIB_DIR) $(BIN_DIR)\$(NAME).exe 
+all: all-noflash
+
+all-noflash: $(LIB_DIR) $(BIN_DIR)\$(NAME).exe 
 
 $(LIB_DIR) :
 	if not exist $(LIB_DIR)\$(NULL) mkdir $(LIB_DIR)

--- a/tools/mclocal.js
+++ b/tools/mclocal.js
@@ -24,6 +24,7 @@ export default class extends TOOL {
 	constructor(argv) {
 		super(argv);
 		this.debug = false;
+		this.noFlash = false;
 		this.inputPaths = [];
 		this.name = "locals";
 		this.outputPath = null;
@@ -36,6 +37,9 @@ export default class extends TOOL {
 			switch (option) {
 			case "-d":
 				this.debug = true;
+				break;
+			case "-n":
+				this.noFlash = true;
 				break;
 			case "-o":
 				argi++;	

--- a/tools/mcmanifest.js
+++ b/tools/mcmanifest.js
@@ -932,6 +932,9 @@ export class Tool extends TOOL {
 				this.debug = true;
 				this.instrument = true;
 				break;
+			case "-n":
+				this.noFlash = true;
+				break;
 			case "-f":
 				argi++;
 				if (argi >= argc)

--- a/tools/skip-flash.py
+++ b/tools/skip-flash.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+#
+# Invoked when mcconfig is invoked with -n (do not flash)
+# Records to-be flashed files and offset
+# This is written without separators or any formatting, so it is easy
+# to use as arguments for esptool.py with something like $(cat map.txt)
+
+import os
+import sys
+
+print( "Skip flashing device: esptool.py arguments will be in " + os.getcwd() + os.path.sep + "map.txt" )
+
+out = open("map.txt","w") 
+ 
+# argv[0] is name of script
+for i in range(1, len(sys.argv), 2):
+    addr    = sys.argv[i]
+    binfile = sys.argv[i+1]
+    out.write( addr + " " + binfile + "\n" )
+
+out.close()


### PR DESCRIPTION
* This is hacky. (Best I could think of given generated Makefiles calling Makefiles.)
* Has not been tested on the PC or Mac (Linux only), however PC nmake changes have been made
* Works by overriding the flash command within the IDF Makefiles with a little python script.
* The python script records the parameters to the flash command that would have been used (sequence of address-binfile pairs). However, that file is currently below .../tmp/... in the IDF build hierarchy and has not been copied over into the Moddable output directory.
