### PR TITLE
only pick ipv4 addresses from g_resolver

### DIFF
--- a/modules/network/net/lin/modResolve.c
+++ b/modules/network/net/lin/modResolve.c
@@ -66,7 +66,8 @@ void resolverCallback(GObject *source_object, GAsyncResult *result, gpointer use
 		GInetAddress *address = (GInetAddress*)addresses->data;
 		if (NULL != address) {
 			char *ip = g_inet_address_to_string(address);
-			if (NULL != ip) {
+			if (NULL != ip &&
+			    g_inet_address_get_family(address) == G_SOCKET_FAMILY_IPV4) {
 				nr->resolved = 1;
 				c_strcpy(nr->ip, ip);
 				g_free(ip);

--- a/modules/network/socket/lin/modSocket.c
+++ b/modules/network/socket/lin/modSocket.c
@@ -453,10 +453,14 @@ void resolverCallback(GObject *source_object, GAsyncResult *result, gpointer use
 	GInetAddress *address = NULL;
 
 	addresses = g_resolver_lookup_by_name_finish(resolver, result, NULL);
-	if (NULL != addresses) {
+	while (NULL != addresses) {
 		address = (GInetAddress*)addresses->data;
-		if (NULL != address)
+		if (NULL != address &&
+		    g_inet_address_get_family(address) == G_SOCKET_FAMILY_IPV4) {
 			ip = g_inet_address_to_string(address);
+			break;
+		}
+		addresses = addresses->next;
 	}
 
 	if (NULL != ip) {


### PR DESCRIPTION
The rest of mockSocket.c uses AF_INET, which is IPv4-only.  So when
resolving names, skip over anything that isn't an IPv4 address.

fixes: https://github.com/Moddable-OpenSource/moddable/issues/298

cc @bfriedkin