### PR TITLE
export mxPromiseStatus() as fxPromiseIsPending(), fxPromiseIsRejected()

### DIFF
--- a/xs/sources/xsPromise.c
+++ b/xs/sources/xsPromise.c
@@ -1439,4 +1439,16 @@ txS1 fxPromiseIsPending(txMachine* the, txSlot* instance) {
 	return status->value.integer == mxPendingStatus;
 }
 
+txS1 fxPromiseIsRejected(txMachine* the, txSlot* instance) {
+	if (instance->kind != XS_REFERENCE_KIND) {
+		return 0;
+	}
+	txSlot *promise = instance->value.reference;
+	if (!mxIsPromise(promise)) {
+		return 0;
+	}
+	txSlot* status = mxPromiseStatus(promise);
+	return status->value.integer == mxRejectedStatus;
+}
+
 

--- a/xs/sources/xsPromise.c
+++ b/xs/sources/xsPromise.c
@@ -1427,6 +1427,16 @@ void fxRunPromiseJobs(txMachine* the)
 }
 
 
-
+txS1 fxPromiseIsPending(txMachine* the, txSlot* instance) {
+	if (instance->kind != XS_REFERENCE_KIND) {
+		return 0;
+	}
+	txSlot *promise = instance->value.reference;
+	if (!mxIsPromise(promise)) {
+		return 0;
+	}
+	txSlot* status = mxPromiseStatus(promise);
+	return status->value.integer == mxPendingStatus;
+}
 
 


### PR DESCRIPTION
This allows a platform to run an event loop until a promise returned from `main()` is resolved and to set the process exit code to non-zero if the promise was rejected.

Perhaps the 2 new functions should be combined?