### PR TITLE
Remove unused imports in comodetto examples

### DIFF
--- a/examples/commodetto/clock/main.js
+++ b/examples/commodetto/clock/main.js
@@ -17,7 +17,6 @@
  */
 
 import Timer from "timer";
-import parseBMF from "commodetto/parseBMF";
 import parseBMP from "commodetto/parseBMP";
 import Poco from "commodetto/Poco";
 import Resource from "Resource";

--- a/examples/commodetto/docs/main.js
+++ b/examples/commodetto/docs/main.js
@@ -15,7 +15,6 @@
 import parseBMF from "commodetto/parseBMF";
 import parseBMP from "commodetto/parseBMP";
 import BufferOut from "commodetto/BufferOut";
-import Bitmap from "commodetto/Bitmap";
 import JPEG from "commodetto/readJPEG";
 import loadJPEG from "commodetto/loadJPEG";
 import Poco from "commodetto/Poco";

--- a/examples/commodetto/origin/main.js
+++ b/examples/commodetto/origin/main.js
@@ -13,7 +13,6 @@
  */
 
 import Poco from "commodetto/Poco";
-import Resource from "Resource";
 
 let render = new Poco(screen);
 

--- a/examples/commodetto/text/main.js
+++ b/examples/commodetto/text/main.js
@@ -12,9 +12,7 @@
  *
  */
 
-import Timer from "timer";
 import parseBMF from "commodetto/parseBMF";
-import parseBMP from "commodetto/parseBMP";
 import Poco from "commodetto/Poco";
 import Resource from "Resource";
 


### PR DESCRIPTION
Remove unused imports in examples as they can make reading and understanding code a bit more difficult for beginners.