### PR TITLE
make servo example work out of the box

### DIFF
--- a/modules/pins/servo/esp/modServo.cpp
+++ b/modules/pins/servo/esp/modServo.cpp
@@ -21,7 +21,7 @@
 #include "xsmc.h"
 #include "mc.xs.h"			// for xsID_ values
 
-#include "servo.h"
+#include "Servo.h"
 
 typedef struct {
 	Servo		*s;

--- a/modules/pins/servo/manifest.json
+++ b/modules/pins/servo/manifest.json
@@ -1,6 +1,6 @@
 {
 	"build": {
-		"ARDUINO_ESP8266": "/Users/$(USER)/esp/esp8266-2.3.0/",
+		"ARDUINO_ESP8266": "$(HOME)/esp/esp8266-2.3.0/",
 	},
 	"platforms":{
 		"esp": {


### PR DESCRIPTION
I'm using ubuntu 16.04, so the `/Users/...` path in the manifest didn't work for me. I also found that `Servo.h` is actually capitalized in the esp8266 library.