### PR TITLE
get isIps flag before SPI initialization

### DIFF
--- a/build/devices/esp32/targets/m5stack/screen.js
+++ b/build/devices/esp32/targets/m5stack/screen.js
@@ -3,9 +3,9 @@ import Digital from "pins/digital";
 
 export default class extends ILI9341 {
 	constructor(dictionary) {
+		let isIps = Digital.read(33); // TFT_RST
 		super(dictionary);
-
-		if (Digital.read(33))		// TFT_RST
+		if (isIps)
 			super.command(0x21);	// invert
 	}
 }


### PR DESCRIPTION
I found that `screen.js` of current Moddable build does not work on my old M5Stack.

This PR fixes the timing of getting is-IPS flag according to [the original driver implementation of M5Stack](https://github.com/m5stack/M5Stack/blob/5b4a619cb4c0122d0c847714200c370c2e77b3a9/src/utility/In_eSPI.cpp#L367).

I don't understand the root cause but getting the is-IPS flag shall be before sending initialization commands. I confirmed this change works on both of my old and new M5Stack.