### PR TITLE
Use M5Button for M5stack

### DIFF
--- a/build/devices/esp32/targets/m5stack/manifest.json
+++ b/build/devices/esp32/targets/m5stack/manifest.json
@@ -1,6 +1,7 @@
 {
 	"include": [
-		"$(MODDABLE)/modules/drivers/ili9341/manifest.json"
+		"$(MODDABLE)/modules/drivers/ili9341/manifest.json",
+		"$(MODDABLE)/modules/pins/digital/monitor/manifest.json"
 	],
 	"config": {
 		"screen": "m5stack/screen",
@@ -68,15 +69,14 @@
 	},
 	"modules": {
 		"*": [
-			"$(MODULES)/pins/digital/monitor/*",
-			"$(MODULES)/pins/digital/monitor/esp32/*"
+			"../m5stack_fire/m5button"
 		],
 		"pins/audioout": "$(MODULES)/pins/i2s/*",
 		"setup/target": "./setup-target",
 		"m5stack/screen": "./screen"
 	},
 	"preload": [
-		"monitor",
+		"m5button",
 		"pins/audioout",
 		"setup/target",
 		"m5stack/screen"

--- a/build/devices/esp32/targets/m5stack/setup-target.js
+++ b/build/devices/esp32/targets/m5stack/setup-target.js
@@ -1,24 +1,13 @@
-import Digital from "pins/digital";
-import Monitor from "monitor";
-
+import M5Button from "m5button";
 import AudioOut from "pins/audioout";
 import Resource from "Resource";
 import config from "mc/config";
 
-class Button extends Monitor {
-	constructor(pin) {
-		super({pin, mode: Digital.InputPullUp, edge: Monitor.Rising | Monitor.Falling});
-		this.onChanged = this.nop;
-	}
-	nop() {
-	}
-}
-
 export default function (done) {
 	global.button = {
-		a: new Button(39),
-		b: new Button(38),
-		c: new Button(37),
+		a: new M5Button(39),
+		b: new M5Button(38),
+		c: new M5Button(37)
 	};
 
 	global.speaker = new AudioOut({streams: 4, });


### PR DESCRIPTION
When Wi-Fi is enabled, button fire often.
Use M5Button to debounce them like other M5* products.