### PR TITLE
Removed nonworking SPI mode-setting code from qca4020, updated gecko

### DIFF
--- a/modules/pins/spi/gecko/modSPI.c
+++ b/modules/pins/spi/gecko/modSPI.c
@@ -128,10 +128,10 @@ void modSPIInit(modSPIConfiguration config)
 	
 	switch (config->mode) {
 		case 3:
-			spiInit.clockMode = usartClockMode2;   // CPOL = 1, CPHA = 1
+			spiInit.clockMode = usartClockMode3;   // CPOL = 1, CPHA = 1
 			break;
 		case 2:
-			spiInit.clockMode = usartClockMode3;   // CPOL = 1, CPHA = 0
+			spiInit.clockMode = usartClockMode2;   // CPOL = 1, CPHA = 0
 			break;
 		case 1:
 			spiInit.clockMode = usartClockMode1;   // CPOL = 0, CPHA = 1

--- a/modules/pins/spi/qca4020/modSPI.c
+++ b/modules/pins/spi/qca4020/modSPI.c
@@ -105,22 +105,6 @@ void modSPIInit(modSPIConfiguration config)
 		config->spi_config.deassertion_Time_Ns = 0;
 		config->spi_config.loopback_Mode = 0;
 		config->spi_config.hs_Mode = 0;
-		
-		switch (config->mode) {
-			case 3:
-				config->spi_config.SPIM_Mode = QAPI_SPIM_MODE_3_E;   // CPOL = 1, CPHA = 1
-				break;
-			case 2:
-				config->spi_config.SPIM_Mode = QAPI_SPIM_MODE_2_E;   // CPOL = 1, CPHA = 0
-				break;
-			case 1:
-				config->spi_config.SPIM_Mode = QAPI_SPIM_MODE_1_E;   // CPOL = 0, CPHA = 1
-				break;
-			case 0:
-			default:
-				config->spi_config.SPIM_Mode = QAPI_SPIM_MODE_0_E;   // CPOL = 0, CPHA = 0
-				break;
-		}
 
 		qurt_signal_create(&config->spi_signal);
 


### PR DESCRIPTION
It seems the code for setting the SPI mode on qca4020 in PR #493 was wrong and I removed it since I have no documentation to refer to. It should be pretty straight forward to implement using the correct documentation.

I also updated the SPI-mode setting code for gecko to correspond with the documentation (SDK version 5.4) for the `USART_ClockMode_TypeDef` enum: https://docs.silabs.com/mcu/5.4/efr32mg13/group-USART#ga9308807377a9f1b25c19bc60d9f64674
I don't remember why I previously changed mode 2 and 3 around for gecko, but according to the documentation and the information about [SPI modes on Wikipedia](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface#Mode_numbers) the current patch should be correct.
