### PR TITLE
Linux Preferences module

### DIFF
--- a/modules/files/preference/lin/preference.js
+++ b/modules/files/preference/lin/preference.js
@@ -1,0 +1,63 @@
+import {File} from "file";
+import config from "mc/config";
+
+export default class Preference {
+    static _prefCache;
+
+    static set(domain, key, value) {
+        Preference._load();
+        if (Preference._prefCache[domain] == undefined)
+            Preference._prefCache[domain] = {};
+		Preference._prefCache[domain][key] = value;
+		Preference._save();
+	}
+
+    static get(domain, key) {
+        Preference._load();
+		return Preference._prefCache[domain] ? Preference._prefCache[domain][key] : undefined;
+	}
+
+    static delete(domain, key) {
+        Preference._load();
+		if ( (Preference._prefCache[domain] !== undefined) && (Preference._prefCache[domain][key] !== undefined) ) {
+			delete Preference._prefCache[domain][key];
+			if (Object.keys(Preference._prefCache[domain]).length == 0)
+				delete Preference._prefCache[domain];
+			Preference._save();
+		}
+	}
+
+    static keys(domain) {
+        Preference._load();
+		return Preference._prefCache[domain] ? Object.keys(Preference._prefCache[domain]) : [];
+	}
+
+	static get _filePath() {
+		return config.file.root + "preferences.json";
+	}
+
+	static _load() {
+        if (Preference._prefCache === undefined) {
+            try {
+                let file = new File(Preference._filePath, false);
+                Preference._prefCache = JSON.parse(file.read(String));
+                file.close();
+            } catch {
+                // ignore errors
+                Preference._prefCache = {};
+            }
+        }
+	}
+
+	static _save() {
+        try {
+            File.delete(Preference._filePath);
+            let file = new File(Preference._filePath, true);
+            file.write(JSON.stringify(Preference._prefCache));
+            file.close();
+        } catch {
+            // ignore errors
+        }
+	}
+}
+

--- a/modules/files/preference/manifest.json
+++ b/modules/files/preference/manifest.json
@@ -1,45 +1,96 @@
 {
-	"modules": {
-		"*": [
-			"$(MODULES)/files/preference/*"
-		]
-	},
-	"preload": [
-		"preference"
-	],
 	"platforms": {
 		"esp": {
 			"modules": {
 				"*": [
+					"$(MODULES)/files/preference/*",
 					"$(MODULES)/files/preference/esp/*"
 				]
-			}
+			},
+			"preload": [
+				"preference"
+			]		
 		},
 		"esp32": {
 			"modules": {
 				"*": [
+					"$(MODULES)/files/preference/*",
 					"$(MODULES)/files/preference/esp32/*"
 				]
-			}
+			},
+			"preload": [
+				"preference"
+			]
 		},
 		"gecko": {
 			"modules": {
 				"*": [
+					"$(MODULES)/files/preference/*",
 					"$(MODULES)/files/preference/gecko/*"
 				]
-			}
+			},
+			"preload": [
+				"preference"
+			]
 		},
 		"mac": {
 			"modules": {
 				"*": [
+					"$(MODULES)/files/preference/*",
 					"$(MODULES)/files/preference/mac/*"
 				]
-			}
+			},
+			"preload": [
+				"preference"
+			]
+		},
+		"cli-mac": {
+			"modules": {
+				"*": [
+					"$(MODULES)/files/preference/*",
+					"$(MODULES)/files/preference/mac/*"
+				]
+			},
+			"preload": [
+				"preference"
+			]
 		},
 		"win": {
 			"modules": {
 				"*": [
+					"$(MODULES)/files/preference/*",
 					"$(MODULES)/files/preference/win/*"
+				]
+			},
+			"preload": [
+				"preference"
+			]
+		},
+		"cli-win": {
+			"modules": {
+				"*": [
+					"$(MODULES)/files/preference/*",
+					"$(MODULES)/files/preference/win/*"
+				]
+			},
+			"preload": [
+				"preference"
+			]
+		},
+		"lin": {
+			"include": [
+				"$(MODULES)/files/file/manifest.json"
+			],
+			"modules": {
+				"*": [
+					"$(MODULES)/files/preference/lin/*"
+				]
+			}
+		},
+		"cli-lin": {
+			"modules": {
+				"*": [
+					"$(MODULES)/files/preference/lin/*"
 				]
 			}
 		}


### PR DESCRIPTION
Simple implementation of a Preferences module using JS.  Not very memory efficient as it loads the preferences as JSON into memory, and then converts it to an object.  Manifest was modified so that the JS version can be used (without Preload, as I need a writable class static member) vs. the .c version used by the other platforms.