### PR TITLE
set/get brightness for M5stack core2

### DIFF
--- a/build/devices/esp32/targets/m5stack_core2/setup-target.js
+++ b/build/devices/esp32/targets/m5stack_core2/setup-target.js
@@ -189,6 +189,21 @@ class Power extends AXP192 {
       this.writeByte(0x90, (this.readByte(0x90) & 0xf8) | 0x01); //set GPIO0 to float , using enternal pulldown resistor to enable supply from BUS_5VS
     }
   }
+  
+  // value 0 - 100 %
+  set brightness(value) {
+    if (value <= 0)
+      value = 2500;
+    else if (value >= 100)
+      value = 3300;
+    else
+      value = (value / 100) * 800 + 2500;
+    this.lcd.voltage = value;
+  }
+  
+  get brightness() {
+    return (this.lcd.voltage - 2500) / 800 * 100;
+  }
 }
 
 function nop() {}


### PR DESCRIPTION
Setting DC3 voltage from 2500 to 3300 can be used for change the LCD brightness.

![file_000](https://user-images.githubusercontent.com/11245747/107849403-4d5e8580-6e3e-11eb-8a69-2e1d7094ebe0.gif)
