### PR TITLE
Microphone support for M5StackCore2 and M5StickC

### DIFF
--- a/build/devices/esp32/targets/m5stack_core2/manifest.json
+++ b/build/devices/esp32/targets/m5stack_core2/manifest.json
@@ -72,6 +72,16 @@
 				"lr_pin": 0,
 				"dataout_pin": 2
 			}
+		},
+		"audioIn": {
+			"sampleRate": 11025,
+			"bitsPerSample": 16,
+			"i2s": {
+				"bck_pin": 12,
+				"lr_pin": 0,
+				"datain": 34,
+				"pdm": 1
+			}
 		}
 	},
 	"modules": {

--- a/build/devices/esp32/targets/m5stick_c/manifest.json
+++ b/build/devices/esp32/targets/m5stick_c/manifest.json
@@ -61,6 +61,15 @@
                  "kDelayMS, 100,",
 				 "kDelayMS, 0"
             ]
+		},
+		"audioIn": {
+			"sampleRate": 11025,
+			"bitsPerSample": 16,
+			"i2s": {
+				"lr_pin": 0,
+				"datain": 34,
+				"pdm": 1
+			}
 		}
 	},
 	"modules": {

--- a/build/devices/esp32/targets/m5stick_c/setup-target.js
+++ b/build/devices/esp32/targets/m5stick_c/setup-target.js
@@ -133,6 +133,7 @@ class Power extends AXP192 {
     this.write(0xb8, 0x80); // Enable Colume Counter
     this.write(0x12, 0x4d); // Enable DC-DC1, OLED VDD, 5B V EXT
     this.write(0x36, 0x5c); // PEK
+    this.write(0x91, 0xA0); // Set MIC voltage to 2.8V
     this.write(0x90, 0x02); // gpio0
   }
 


### PR DESCRIPTION
I confirmed `examples/pins/audioin/waveserver` application works.