### PR TITLE
Improve type definition

### DIFF
--- a/typings/piu/MC.d.ts
+++ b/typings/piu/MC.d.ts
@@ -513,37 +513,6 @@ declare module "piu/MC" {
     new(behaviorData: any, dictionary: ScrollerDictionary): Scroller;
   }
 
-  interface Timeline {
-    duration: number;
-    fraction: number;
-    time: number;
-    from(
-      target: object,
-      fromProperties: object,
-      duration: number,
-      easing?: string,
-      delay?: number
-    ): Timeline;
-    on(
-      target: object,
-      onProperties: object,
-      duration: number,
-      easing?: number,
-      delay?: number
-    ): Timeline;
-    seekTo(time: number): void;
-    to(
-      target: object,
-      fromProperties: object,
-      duration: number,
-      easing?: string,
-      delay?: number
-    ): Timeline;
-  }
-  interface TimelineConstructor {
-    new(): Timeline
-  }
-
   global {
     const Skin: SkinConstructor
     const Texture: TextureConstructor
@@ -561,7 +530,6 @@ declare module "piu/MC" {
     const Label: LabelConstructor
     const Transition: TransitionConstructor
     const Text: TextConstructor
-    const Timeline: TimelineConstructor
   }
  }
 

--- a/typings/piu/MC.d.ts
+++ b/typings/piu/MC.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Shinya Ishikawa
+ * Copyright (c) 2020-2021 Shinya Ishikawa
  *
  *   This file is part of the Moddable SDK Tools.
  *

--- a/typings/piu/Timeline.d.ts
+++ b/typings/piu/Timeline.d.ts
@@ -1,0 +1,31 @@
+
+declare module "piu/Timeline" {
+  class Timeline {
+    duration: number;
+    fraction: number;
+    time: number;
+    from(
+      target: object,
+      fromProperties: object,
+      duration: number,
+      easing?: string,
+      delay?: number
+    ): Timeline;
+    on(
+      target: object,
+      onProperties: object,
+      duration: number,
+      easing?: number,
+      delay?: number
+    ): Timeline;
+    seekTo(time: number): void;
+    to(
+      target: object,
+      fromProperties: object,
+      duration: number,
+      easing?: string,
+      delay?: number
+    ): Timeline;
+  }
+  export { Timeline as default }
+}

--- a/typings/piu/Timeline.d.ts
+++ b/typings/piu/Timeline.d.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2020-2021 Shinya Ishikawa
+ *
+ *   This file is part of the Moddable SDK Tools.
+ *
+ *   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Tools is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 declare module "piu/Timeline" {
   class Timeline {

--- a/typings/serial.d.ts
+++ b/typings/serial.d.ts
@@ -1,0 +1,28 @@
+declare module "serial" {
+  class Serial {
+    public constructor()
+    public setTimeout(ms: number): void
+    public setBaudrate(baud: number): void
+
+    public available(): boolean
+    public flush(): void
+
+    public readBytes(bytes: number): string
+    public readBytes(buffer: ArrayBuffer, bytes?: number): void
+    public readLine(): string
+    public readLineUntil(terminator: string): string
+    public readBytesUntil(character: string, bytes: number): string
+    public readBytesUntil(buffer: ArrayBuffer, character: string, bytes: number): void
+
+    public write(msg: ArrayBufferLike): void
+    public write(msg: ArrayBufferLike, from: number): void
+    public write(msg: ArrayBufferLike, from: number, to: number): void
+
+    public write(): void
+    public writeLine(line: string): void
+    public onDataReceived: (str: string, len: number) => void
+    public poll(dictionary: { terminators: string | string[]; trim: number; chunkSize: number }): void
+    public poll(): void
+  }
+  export { Serial as default }
+}

--- a/typings/serial.d.ts
+++ b/typings/serial.d.ts
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) 2021 Shinya Ishikawa
+ *
+ *   This file is part of the Moddable SDK Tools.
+ *
+ *   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Tools is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 declare module "serial" {
   class Serial {
     public constructor()


### PR DESCRIPTION
* Separated `piu/Timeline` type definition from `piu/MC`. Otherwise it throws module-not-found error like below.

```
../extern/avatar/src/emoticon.ts:2:22 - error TS2792: Cannot find module 'piu/Timeline'. Did you mean to set the 'moduleResolution' option to 'node', or to add aliases to the 'paths' option?

2 import Timeline from 'piu/Timeline'
                       ~~~~~~~~~~~~~~
```

* Added type definition for contributed `serial` module. I understand these API will be gradually moved to which uses TC53 specification. But it is necessary for [my ongoing project](https://github.com/meganetaaan/stack-chan) to build. Will be pleased if you consider it.