### PR TITLE
Config for startup vibration in M5stack core2

### DIFF
--- a/build/devices/esp32/targets/m5stack_core2/manifest.json
+++ b/build/devices/esp32/targets/m5stack_core2/manifest.json
@@ -11,7 +11,8 @@
 	"config": {
 		"screen": "ili9341",
 		"touch": "ft6206",
-		"startupSound": "bflatmajor.maud"
+		"startupSound": "bflatmajor.maud",
+		"startupVibration": 600
 	},
 	"defines": {
 		"i2c": {

--- a/build/devices/esp32/targets/m5stack_core2/setup-target.js
+++ b/build/devices/esp32/targets/m5stack_core2/setup-target.js
@@ -60,10 +60,12 @@ export default function (done) {
     },
   };
 
-  vibration.write(true);
-  Timer.set(() => {
-    vibration.write(false);
-  }, 600);
+  if (config.startupVibration) {
+    vibration.write(true);
+    Timer.set(() => {
+      vibration.write(false);
+    }, config.startupVibration);
+  }
 
   // accelerometer and gyrometer
   state.accelerometerGyro = new MPU6886(INTERNAL_I2C);


### PR DESCRIPTION
We can use this config to change duration of startup vibration.