### PR TITLE
add rmt examples and type definition

### DIFF
--- a/examples/pins/rmt/ir-receive/main.js
+++ b/examples/pins/rmt/ir-receive/main.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Satoshi Tanaka
+ *
+ *   This file is part of the Moddable SDK.
+ *
+ *   This work is licensed under the
+ *       Creative Commons Attribution 4.0 International License.
+ *   To view a copy of this license, visit
+ *       <https://creativecommons.org/licenses/by/4.0>.
+ *   or send a letter to Creative Commons, PO Box 1866,
+ *   Mountain View, CA 94042, USA.
+ *
+ */
+
+import RMT from "pins/rmt";
+import Timer from "timer";
+
+const IrReceivePin = 33;
+let inputRMT = new RMT({pin: IrReceivePin, channel: 0, divider: 80, direction: "rx", filter: 255, timeout: 30000, ringbufferSize: 512});
+
+const data = new Uint16Array(512);
+
+Timer.repeat(() => {
+	let result = inputRMT.read(data.buffer);
+	if (result.count) {
+		trace(`rawData[${result.count}] =\n[`);
+		for (let i = 0; i < result.count; i++) {
+			trace(`${data[i]}`);
+			if(i != result.count -1) trace(", ");
+		}
+		trace(`]\n`);
+	}
+}, 100);
+

--- a/examples/pins/rmt/ir-receive/manifest.json
+++ b/examples/pins/rmt/ir-receive/manifest.json
@@ -1,0 +1,9 @@
+{
+	"include": [
+		"$(MODDABLE)/examples/manifest_base.json",
+		"$(MODULES)/pins/rmt/manifest.json"
+	],
+	"modules": {
+		"*": "./main"
+	}
+}

--- a/examples/pins/rmt/ir-send/main.js
+++ b/examples/pins/rmt/ir-send/main.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Satoshi Tanaka
+ *
+ *   This file is part of the Moddable SDK.
+ *
+ *   This work is licensed under the
+ *       Creative Commons Attribution 4.0 International License.
+ *   To view a copy of this license, visit
+ *       <https://creativecommons.org/licenses/by/4.0>.
+ *   or send a letter to Creative Commons, PO Box 1866,
+ *   Mountain View, CA 94042, USA.
+ *
+ */
+
+import RMT from "pins/rmt";
+
+const IrSendPin = 9; 	// M5StickC transmitter pin
+let rmt = new RMT({pin: IrSendPin, channel: 0, divider: 80, direction: "tx",
+					tx_config: {
+						loop_en: 0,
+						carrier_freq_hz: 38000,
+						carrier_duty_percent: 33,
+						carrier_level: 1,
+						carrier_en: 1,
+						idle_level: 0,
+						idle_output_en: 0
+					}});
+
+rmt.onWritable = function() {}
+
+//  power button of Sony TV 
+let rawData = [2380, 602, 1184, 604, 588, 604, 1186, 604, 588, 604, 1184, 604, 588, 604, 588, 604, 1186, 604, 588, 604, 588, 604,  588, 604, 588, 25704, 2382, 604, 1184, 604, 586, 606, 1186, 604, 588, 604, 1186, 602, 588, 606, 588, 604, 1186, 604, 588, 604, 588, 608, 584, 606, 588, 25712, 2382, 602, 1186, 604, 588, 604, 1184, 604, 588, 604, 1186, 604, 586, 606, 588, 604, 1186, 602,  592, 600,  588, 604,  588, 604, 588];
+
+button.a.onChanged = function(){
+	if(button.a.read()) return;
+
+	rmt.write(1, rawData);
+}

--- a/examples/pins/rmt/ir-send/manifest.json
+++ b/examples/pins/rmt/ir-send/manifest.json
@@ -1,0 +1,9 @@
+{
+	"include": [
+		"$(MODDABLE)/examples/manifest_base.json",
+		"$(MODULES)/pins/rmt/manifest.json"
+	],
+	"modules": {
+		"*": "./main"
+	}
+}

--- a/typings/pins/rmt.d.ts
+++ b/typings/pins/rmt.d.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Satoshi Tanaka
+ *
+ *   This file is part of the Moddable SDK Tools.
+ *
+ *   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Tools is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+declare module 'pins/rmt' {
+  class RMT {
+    public constructor(
+      dictionary: {
+        pin: number,
+        channel?: number,
+        divider?: number,
+        direction?: "tx" | "rx",
+        filter?: number,
+        timeout?: number,
+        ringbufferSize?: number,
+        tx_config?: {
+          loop_en: 0 | 1,
+          carrier_freq_hz: number,
+          carrier_duty_percent: number,
+          carrier_level:0 | 1,
+          carrier_en: 0 | 1,
+          idle_level: 0 | 1,
+          idle_output_en: 0 | 1
+        }
+      }
+    );
+    public write(firstValue: 0 | 1, durations: number[]): void;
+    public onWritable: () => void;
+    public read(buffer: ArrayBuffer | ArrayBufferLike): {buffer: ArrayBuffer, count: number, phase: 0 | 1};
+    public close();
+  }
+  export { RMT as default }
+}


### PR DESCRIPTION
* add ir send and ir receive examples which using `rmt` module.
  * I confirmed these examples with built-in ir transmitter of M5stick-c and [IR Unit of M5stack](https://docs.m5stack.com/en/unit/ir).

* add type definition for `rmt` module.