### PR TITLE
removing slashes in RTOS path

### DIFF
--- a/documentation/devices/esp8266.md
+++ b/documentation/devices/esp8266.md
@@ -74,7 +74,7 @@ We have also used many displays with the ESP8266 Node MCU board. The following t
 <a id="mac"></a>
 ## macOS
 
-The Moddable SDK build for ESP8266 currently uses ESP8266 Arduino Core 2.3.0 and ESP8266\_RTOS\_SDK v3.2. 
+The Moddable SDK build for ESP8266 currently uses ESP8266 Arduino Core 2.3.0 and ESP8266_RTOS_SDK v3.2. 
 
 <a id="mac-instructions"></a>
 ### Installing
@@ -99,17 +99,17 @@ The Moddable SDK build for ESP8266 currently uses ESP8266 Arduino Core 2.3.0 and
 
 6. Download the [ESP8266 core for Arduino repository](https://github.com/esp8266/Arduino/releases/download/2.3.0/esp8266-2.3.0.zip). Copy the extracted `esp8266-2.3.0` folder into your `~/esp` directory.
 
-7. Clone the [ESP8266 SDK based on FreeRTOS](https://github.com/espressif/ESP8266\_RTOS\_SDK) repository into the `~/esp` directory:
+7. Clone the [ESP8266 SDK based on FreeRTOS](https://github.com/espressif/ESP8266_RTOS_SDK) repository into the `~/esp` directory:
 
 	```text
 	cd ~/esp
-	git clone https://github.com/espressif/ESP8266\_RTOS\_SDK.git
+	git clone https://github.com/espressif/ESP8266_RTOS_SDK.git
 	```
 
 	We need version 3.2:
 
 	```text
-	cd ESP8266\_RTOS\_SDK
+	cd ESP8266_RTOS_SDK
 	git checkout release/v3.2
 	```
 	
@@ -223,17 +223,17 @@ The Moddable SDK build for ESP8266 currently uses ESP8266 Arduino Core 2.3.0 and
 
 7. Download the [ESP8266 core for Arduino repository](https://github.com/esp8266/Arduino/releases/download/2.3.0/esp8266-2.3.0.zip). Copy the extracted `esp8266-2.3.0` folder into your `esp` directory.
 
-8. Clone the [ESP8266 SDK based on FreeRTOS](https://github.com/espressif/ESP8266\_RTOS\_SDK) repository into the `~/esp` directory:
+8. Clone the [ESP8266 SDK based on FreeRTOS](https://github.com/espressif/ESP8266_RTOS_SDK) repository into the `~/esp` directory:
 
 	```text
 	cd C:\Users\<user>\esp
-	git clone https://github.com/espressif/ESP8266\_RTOS\_SDK.git
+	git clone https://github.com/espressif/ESP8266_RTOS_SDK.git
 	```
 
 	We need version 3.2:
 
 	```text
-	cd ESP8266\_RTOS\_SDK
+	cd ESP8266_RTOS_SDK
 	git checkout release/v3.2
 	```
 
@@ -314,10 +314,10 @@ To ensure that your build environment is up to date, perform the following steps
 
 1. Download the [ESP8266 core for Arduino repository](https://github.com/esp8266/Arduino/releases/download/2.3.0/esp8266-2.3.0.zip). Copy the extracted `esp8266-2.3.0` folder into your `esp` directory.
 
-2. Update your cloned copy of the [ESP8266 SDK based on FreeRTOS](https://github.com/espressif/ESP8266\_RTOS\_SDK) and select the release/v3.2 branch. For instance, using `Git Bash`:
+2. Update your cloned copy of the [ESP8266 SDK based on FreeRTOS](https://github.com/espressif/ESP8266_RTOS_SDK) and select the release/v3.2 branch. For instance, using `Git Bash`:
 
 	```text
-	cd ~/esp/ESP8266\_RTOS\_SDK
+	cd ~/esp/ESP8266_RTOS_SDK
     git fetch
     git checkout release/v3.2
     git pull
@@ -341,7 +341,7 @@ To ensure that your build environment is up to date, perform the following steps
 <a id="lin"></a>
 ## Linux
 
-The Moddable SDK build for ESP8266 currently uses ESP8266 Arduino Core 2.3.0 and ESP8266\_RTOS\_SDK v3.2. 
+The Moddable SDK build for ESP8266 currently uses ESP8266 Arduino Core 2.3.0 and ESP8266_RTOS_SDK v3.2. 
 
 <a id="lin-instructions"></a>
 ### Installing
@@ -355,17 +355,17 @@ The Moddable SDK build for ESP8266 currently uses ESP8266 Arduino Core 2.3.0 and
 
 4. Download the [ESP8266 core for Arduino repository](https://github.com/esp8266/Arduino/releases/download/2.3.0/esp8266-2.3.0.zip). Copy the extracted `esp8266-2.3.0` folder into your `~/esp` directory.
 
-5. Clone the [ESP8266 SDK based on FreeRTOS](https://github.com/espressif/ESP8266\_RTOS\_SDK) repository into the `~/esp` directory:
+5. Clone the [ESP8266 SDK based on FreeRTOS](https://github.com/espressif/ESP8266_RTOS_SDK) repository into the `~/esp` directory:
 
 	```text
 	cd ~/esp
-	git clone https://github.com/espressif/ESP8266\_RTOS\_SDK.git
+	git clone https://github.com/espressif/ESP8266_RTOS_SDK.git
 	```
 
 	We need version 3.2:
 
 	```text
-	cd ESP8266\_RTOS\_SDK
+	cd ESP8266_RTOS_SDK
 	git checkout release/v3.2
 	```
 
@@ -449,10 +449,10 @@ To ensure that your build environment is up to date, perform the following steps
 
 1. Download the [ESP8266 core for Arduino repository](https://github.com/esp8266/Arduino/releases/download/2.3.0/esp8266-2.3.0.zip). Copy the extracted `esp8266-2.3.0` folder into your `~/esp` directory.
 
-2. Update your cloned copy of the [ESP8266 SDK based on FreeRTOS](https://github.com/espressif/ESP8266\_RTOS\_SDK) and select the release/v3.2 branch:
+2. Update your cloned copy of the [ESP8266 SDK based on FreeRTOS](https://github.com/espressif/ESP8266_RTOS_SDK) and select the release/v3.2 branch:
 
 	```text
-	cd ~/esp/ESP8266\_RTOS\_SDK
+	cd ~/esp/ESP8266_RTOS_SDK
     git fetch
     git checkout release/v3.2
     git pull


### PR DESCRIPTION
the \ in the RTOS paths are not needed and break when doing cut and paste