### PR TITLE
Add module builder for base64

### DIFF
--- a/modules/data/base64/modBase64.c
+++ b/modules/data/base64/modBase64.c
@@ -39,8 +39,8 @@
 	modeled on FskStrB64Decode and FskStrB64Encode from KPR.
 */
 
-#include "xsPlatform.h"
 #include "xs.h"
+#include "xsPlatform.h"
 
 void xs_base64_encode(xsMachine *the)
 {
@@ -166,3 +166,23 @@ void xs_base64_decode(xsMachine *the)
 			break;
 	}
 }
+
+#if !mxNoFunctionLength
+void modInstallBase64(xsMachine *the)
+{
+	#define kNamespace (0)
+	#define kScratch (1)
+
+	xsBeginHost(the);
+	xsVars(2);
+
+  xsVar(kNamespace) = xsNewObject();
+	xsSet(xsGlobal, xsID("Base64"), xsVar(kNamespace));
+	xsVar(kScratch) = xsNewHostFunction(xs_base64_encode, 1);
+	xsSet(xsVar(kNamespace), xsID("encode"), xsVar(kScratch));
+	xsVar(kScratch) = xsNewHostFunction(xs_base64_decode, 1);
+	xsSet(xsVar(kNamespace), xsID("decode"), xsVar(kScratch));
+
+	xsEndHost(the);
+}
+#endif


### PR DESCRIPTION
This adds a builder function for the base64 module to add the functions to global scope, as opposed to the paved path for using it as a module. This aids https://github.com/agoric-labs/xsnap-pub/pull/4

My C is rusty with a small R, so please review skeptically. In particular, I cargoed the `mxNoFunctionLength` pragma from the UTF-8 codec and know not whether it is necessary or even helpful. I was also unable to cult the `mxmc` patterns I observed there without incurring the wrath of the compiler, so I stuck with the simple incantations patterned off precedent in `xsnap`.