### PR TITLE
Heltec Wifi Kit 32 OLED screen support

### DIFF
--- a/build/devices/esp32/targets/heltec_wifi_kit_32/host/provider.js
+++ b/build/devices/esp32/targets/heltec_wifi_kit_32/host/provider.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * FIXME: Analog port needs updating.
+ * NOTES: Not sure how the I2C screen works here.
+ * NOTES: Pins LED is updated.  backlight: 18, displayDC: 2, displaySelect: 15 are placeholders.
+ * Pinout is referenced below.
+ * https://resource.heltec.cn/download/WiFi_Kit_32/WIFI_Kit_32_pinoutDiagram_V2.pdf
+ */
+
+import Analog from "embedded:io/analog";
+import Digital from "embedded:io/digital";
+import DigitalBank from "embedded:io/digitalbank";
+import I2C from "embedded:io/i2c";
+import PulseCount from "embedded:io/pulsecount";
+import PWM from "embedded:io/pwm";
+import Serial from "embedded:io/serial";
+import SMBus from "embedded:io/smbus";
+import SPI from "embedded:io/spi";
+
+const device = {
+	I2C: {
+		default: {
+			io: I2C,
+			data: 21,
+			clock: 22
+		}
+	},
+	Serial: {
+		default: {
+			io: Serial,
+			port: 1,
+			receive: 3,
+			transmit: 1
+		}
+	},
+	SPI: {
+		default: {
+			io: SPI,
+			clock: 18,
+			in: 19,
+			out: 23,
+			port: 1
+		}
+	},
+	Analog: {
+		default: {
+			io: Analog,
+			pin: 35
+		}
+	},
+	io: {Analog, Digital, DigitalBank, I2C, PulseCount, PWM, Serial, SMBus, SPI},
+	pins: {
+		button: 0,
+		led: 25,
+		backlight: 18,
+		displayDC: 2,
+		displaySelect: 15
+	}
+};
+
+export default device;

--- a/build/devices/esp32/targets/heltec_wifi_kit_32/manifest.json
+++ b/build/devices/esp32/targets/heltec_wifi_kit_32/manifest.json
@@ -1,0 +1,29 @@
+{
+	"include": [
+		"$(MODDABLE)/modules/drivers/ssd1306/manifest_i2c.json"
+	],
+	"config": {
+		"screen": "ssd1306",
+		"touch": "",
+		"format": "Gray256"
+	},
+	"defines": {
+		"i2c": {
+			"sda_pin": 21,
+			"scl_pin": 22
+		},
+		"spi": {
+			"miso_pin": 19,
+			"mosi_pin": 23,
+			"sck_pin": 18
+		},
+		"ssd1306": {
+			"hz": 400000,
+			"width": 128,
+			"height": 64,
+			"sda_pin": 4,
+			"scl_pin": 15,
+			"rst_pin": 16
+		}
+	}
+}

--- a/modules/drivers/ssd1306/modSsd1306.c
+++ b/modules/drivers/ssd1306/modSsd1306.c
@@ -131,9 +131,10 @@ struct ssd1606Record {
 #if MODDEF_SSD1306_SPI
 	modGPIOConfigurationRecord	cs;
 	modGPIOConfigurationRecord	dc;
+#endif
+
 #ifdef MODDEF_SSD1306_RST_PIN
 	modGPIOConfigurationRecord	rst;
-#endif
 #endif
 
 	uint8_t				pixel;										// mask for white pixel on current row
@@ -228,25 +229,25 @@ void xs_SSD1306(xsMachine *the)
 
 	ssd->width = (uint8_t)width;
 	ssd->height = (uint8_t)height;
-
-#if MODDEF_SSD1306_SPI
-	SCREEN_CS_INIT;
-	SCREEN_DC_INIT;
+	
 #ifdef MODDEF_SSD1306_RST_PIN
 	SCREEN_RST_INIT;
-#endif
-
-	ssd->config.spi.hz = MODDEF_SSD1306_HZ;
-	ssd->config.spi.doChipSelect = ssd1306ChipSelect;
-	modSPIInit(&ssd->config.spi);
-
-#ifdef MODDEF_SSD1306_RST_PIN
+	// modDelayMilliseconds(10);
 	SCREEN_RST_DEACTIVE;
 	modDelayMilliseconds(1);
 	SCREEN_RST_ACTIVE;
 	modDelayMilliseconds(10);
 	SCREEN_RST_DEACTIVE;
 #endif
+
+#if MODDEF_SSD1306_SPI
+	SCREEN_CS_INIT;
+	SCREEN_DC_INIT;
+
+	ssd->config.spi.hz = MODDEF_SSD1306_HZ;
+	ssd->config.spi.doChipSelect = ssd1306ChipSelect;
+	modSPIInit(&ssd->config.spi);
+
 #elif MODDEF_SSD1306_I2C
 	#ifdef MODDEF_SSD1306_SDA_PIN
 		ssd->config.i2c.sda = MODDEF_SSD1306_SDA_PIN;


### PR DESCRIPTION
This adds support for the Heltec Wifi Kit 32 with OLED screen.  https://heltec.org/project/wifi-kit-32/

This creates the target build directory and needed config files for the Heltec WiFi kit 32 and OLED screen.  

- This required an update to the 1306 driver to support proper resets in i2c path.  The resets should work for both SPI and i2c.  I don't have an SPI 1306 device to test with that requires a reset (RST) pin.  
- The provider.js file is my best attempt with what I understood.  Please review.  

