### PR TITLE
Update wasm.md

### DIFF
--- a/documentation/devices/wasm.md
+++ b/documentation/devices/wasm.md
@@ -45,7 +45,7 @@ This document provides instructions to build and run Moddable SDK apps for the W
 
 	```text
 	cd ~/Projects
-	git clone https://github.com/WebAssembly/binaryen.git
+	git clone --recursive https://github.com/WebAssembly/binaryen.git
 	cd binaryen
 	cmake . && make
 	```


### PR DESCRIPTION
The Binaryen project was recently updated to introduce git submodules: https://github.com/WebAssembly/binaryen/pull/4466

This requires the wasm setup instructions to include the `--recursive` flag when cloning the Binaryen repo or the `cmake .` build command will fail. 