### PR TITLE
#839 Time (relative) in deep sleep

### DIFF
--- a/xs/platforms/esp/xsHost.c
+++ b/xs/platforms/esp/xsHost.c
@@ -642,6 +642,10 @@ void modGetTimeOfDay(struct modTimeVal *tv, struct modTimeZone *tz)
 	}
 }
 
+#if ESP32
+int64_t RTC_SLOW_ATTR __microsecondsOffset = 0;
+#endif
+
 void modSetTime(uint32_t seconds)
 {
 #if !ESP32
@@ -664,7 +668,9 @@ void modSetTime(uint32_t seconds)
 	tv.tv_sec = seconds;
 	tv.tv_usec = 0;
 
+	uint64_t usBefore = kMicroseconds64();
 	settimeofday(&tv, NULL);		//@@ implementation doesn't use timezone yet....
+	__microsecondsOffset += kMicroseconds64() - usBefore;
 #endif
 }
 
@@ -867,9 +873,11 @@ void IRAM_ATTR timer_group0_isr(void *para)
 
 #if ESP32
 
-uint32_t modMilliseconds(void)
+uint64_t kMicroseconds64(void) 
 {
-	return xTaskGetTickCount();
+	struct timeval tv_now;
+	gettimeofday(&tv_now, NULL);
+	return (uint64_t) tv_now.tv_sec * 1000000L + (uint64_t) tv_now.tv_usec - __microsecondsOffset;
 }
 
 #endif

--- a/xs/platforms/esp/xsHost.h
+++ b/xs/platforms/esp/xsHost.h
@@ -153,9 +153,10 @@ extern uint8_t ESP_setBaud(int baud);
 */
 
 #if ESP32
-	extern uint32_t modMilliseconds(void);
-	#define modMicroseconds() (uint32_t)(esp_timer_get_time())
-
+	extern uint64_t kMicroseconds64(void);
+	#define modMilliseconds() ((uint32_t) (kMicroseconds64() / 1000L))
+	#define modMicroseconds() ((uint32_t) kMicroseconds64())
+	
 	#define modDelayMilliseconds(ms) vTaskDelay(ms)
 	#define modDelayMicroseconds(us) vTaskDelay(((us) + 500) / 1000)
 


### PR DESCRIPTION
Implements proposal in #839.  Tested in deep and light sleep, as well as verified time accuracy of the concept (test implementation) over around 14 hours with a deep sleep every second.

I wasn't exactly sure on the correct use of naming.  It appears that the prefix `mod` should be used for C code that is common across all platforms.  I saw `k` being used for perhaps internal ("kernel"?) things, so I created my one new function with that (`kMicroseconds64`).  

