### PR TITLE
fix label for buttons in ButtonsRow for mcsim

### DIFF
--- a/tools/mcsim/ControlsPane.js
+++ b/tools/mcsim/ControlsPane.js
@@ -130,7 +130,7 @@ export var ButtonsRow = Row.template(function($) { return {
 	left:0, right:0, height:30,
 	contents: [
 		Label($, { width:120, style:styles.controlName, string:$.label }),
-		$.buttons.map($$ => new Button($$, { Behavior:ButtonsRowBehavior, string:$.label })),
+		$.buttons.map($$ => new Button($$, { Behavior:ButtonsRowBehavior, string: $$.label })),
 		Content($, { left:0, right:0 }),
 	],
 }});


### PR DESCRIPTION
Currently the buttons in the ButtonsRow are using the parents label caused by a typo `$` instead of `$$`
Current behaviour:
<img width="364" alt="three buttons with the label of the parent" src="https://user-images.githubusercontent.com/1250430/158685340-3f5434ed-2c17-4835-9cbe-8bc97eb626cf.png">

With this PR applied:
<img width="362" alt="three buttons with the correct label applied" src="https://user-images.githubusercontent.com/1250430/158685492-c3ad5197-e710-443a-957a-960726fc7f3c.png">
