### PR TITLE
Add support for HostBuffer on String.fromArrayBuffer

### DIFF
--- a/xs/sources/xsString.c
+++ b/xs/sources/xsString.c
@@ -350,11 +350,11 @@ void fx_String_fromArrayBuffer(txMachine* the)
 	slot = mxArgv(0);
 	if (slot->kind == XS_REFERENCE_KIND) {
 		slot = slot->value.reference->next;
-		if (slot && (slot->kind == XS_ARRAY_BUFFER_KIND))
+		if (slot && (slot->kind == XS_ARRAY_BUFFER_KIND || slot->kind == XS_HOST_KIND))
 			arrayBuffer = slot;
 	}
 	if (!arrayBuffer)
-		mxTypeError("argument is no ArrayBuffer instance");
+		mxTypeError("argument is no ArrayBuffer/HostBuffer instance");
 	bufferInfo = arrayBuffer->next;
 	limit = bufferInfo->value.bufferInfo.length;
 	offset = fxArgToByteLength(the, 1, 0);


### PR DESCRIPTION
This pull extends the buffer sanity test to include `XS_HOST_KIND` (inside of `fx_String_fromArrayBuffer`) so that it can accept either an `ArrayBuffer` or a `HostBuffer`.    

Background: I use `HostBuffer` to map ESP32 fast/slow memory, and then use CDV to map an efficient data structure on top of it.  CDV uses `String.fromArrayBuffer` for strings, which caused an error when the code ran that the buffer was not an `ArrayBuffer`.  This change has been verified to resolve that specific problem when using `HostBuffer`.