### PR TITLE
fix: remove esp32/esp32_thing default display

### DIFF
--- a/build/devices/esp32/targets/esp32_thing/manifest.json
+++ b/build/devices/esp32/targets/esp32_thing/manifest.json
@@ -1,9 +1,6 @@
 {
-	"include": [
-		"$(MODDABLE)/modules/drivers/ili9341/manifest.json"
-	],
 	"config": {
-		"screen": "ili9341",
+		"screen": "",
 		"touch": ""
 	},
 	"defines": {
@@ -15,12 +12,6 @@
 			"miso_pin": 12,
 			"mosi_pin": 13,
 			"sck_pin": 14
-		},
-		"ili9341": {
-			"hz": 40000000,
-			"cs_pin": 15,
-			"dc_pin": 2,
-			"spi_port": "HSPI_HOST"
 		}
 	}
 }


### PR DESCRIPTION
As discussed below the `esp32/esp32_thing` probably should look like `esp32/esp32_thing_plus` and not default a display or include any additional modules.

https://github.com/Moddable-OpenSource/moddable/discussions/921