### PR TITLE
Accept an array of colors for TextureSkinDictionary.color

### DIFF
--- a/documentation/piu/piu.md
+++ b/documentation/piu/piu.md
@@ -3504,7 +3504,7 @@ If there is a `texture` or `Texture` property in the dictionary, the constructor
 | Parameter | Type | Description |
 | --- | --- | :--- |
 | `bottom` | `number` | The skin's bottom tile (setting the `bottom` parameter in the created instance, and `bottom` in the created instance's `tiles` property)
-| `color` | `string` | If the texture has only an alpha bitmap, the value of the `color` property will be used to colorize the bitmap. Must be a string or array of strings of the form specified in the [Colors](colors) section of this document.
+| `color` | `string` or `array` | If the texture has only an alpha bitmap, the value of the `color` property will be used to colorize the bitmap. Must be a string or array of strings of the form specified in the [Colors](colors) section of this document.
 | `left` | `number` | The skin's left tile (setting the `left` parameter in the created instance, and `left` in the created instance's `tiles` property)
 | `right` | `number` | The skin's right tile (setting the `right` parameter in the created instance, and `right` in the created instance's `tiles` property)
 | `states` | `number` | This skin's vertical offset between states, in pixels

--- a/typings/piu/MC.d.ts
+++ b/typings/piu/MC.d.ts
@@ -245,7 +245,7 @@ declare module "piu/MC" {
   interface TextureSkinDictionary extends Coordinates, Bounds {
     texture?: Texture;
     Texture?: TextureConstructor;
-    color?: Color;
+    color?: Color | Color[];
     states?: number;
     variants?: number;
     tiles?: Coordinates;


### PR DESCRIPTION
According the description of `documentation/piu.md`. The `color` property of Texture Skin dictionary should accept not only string but also an array of colors. But the type definition is only for string.

I confirmed the implementation [do accepts an array](https://github.com/Moddable-OpenSource/moddable/blob/86c6dff2cad47b2b72ad52e86de9eb8acfbcb8c0/modules/piu/All/piuSkin.c#L114). So here is a small fix for documentation and typings.