### PR TITLE
added device.I2C hat configuration to M5StickC

### DIFF
--- a/build/devices/esp32/targets/m5stick_c/host/provider.js
+++ b/build/devices/esp32/targets/m5stick_c/host/provider.js
@@ -39,6 +39,11 @@ const device = {
 			io: I2C,
 			data: 21,
 			clock: 22
+		},
+		hat: {
+			io: I2C,
+			data: 0,
+			clock: 26
 		}
 	},
 	Serial: {


### PR DESCRIPTION
M5StickC HAT extension modules use GPIO(G0, G26) as I2C.
![hat_image_04](https://user-images.githubusercontent.com/23477407/197098655-7a30db3e-0755-4018-b160-1d95740eb7b0.jpg)

We can specify HAT in the Sensor node of Node-RED MCU Edition.
![hat_image_02](https://user-images.githubusercontent.com/23477407/197098694-53e69c57-e35a-4ce6-81e8-53eddaf15efe.jpg)
