### PR TITLE
Avoids mixing debug and oss-fuzz flags

### DIFF
--- a/xs/makefiles/lin/xst.mk
+++ b/xs/makefiles/lin/xst.mk
@@ -69,10 +69,7 @@ C_OPTIONS += \
 	-Wno-misleading-indentation \
 	-Wno-implicit-fallthrough
 ifeq ($(GOAL),debug)
-	C_OPTIONS += -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter 
-	LINK_OPTIONS += -fsanitize=address -fno-omit-frame-pointer
-	C_OPTIONS += -DmxASANStackMargin=131072 -fsanitize=address -fno-omit-frame-pointer
-
+	C_OPTIONS += -DmxASANStackMargin=131072
 	ifneq ($(FUZZING),0)
 		C_OPTIONS += -DmxStress=1
 		C_OPTIONS += -DFUZZING=1
@@ -84,7 +81,12 @@ ifeq ($(GOAL),debug)
 		ifneq ($(OSSFUZZ_JSONPARSE),0)
 			C_OPTIONS += -DOSSFUZZ_JSONPARSE=1
 		endif
+	else
+		C_OPTIONS += -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter 
+		LINK_OPTIONS += -fsanitize=address -fno-omit-frame-pointer
+		C_OPTIONS += -fsanitize=address -fno-omit-frame-pointer
 	endif
+
 	ifneq ($(FUZZILLI),0)
 		C_OPTIONS += -DFUZZILLI=1 -fsanitize-coverage=trace-pc-guard
 	endif
@@ -173,7 +175,7 @@ $(BIN_DIR)/$(NAME): $(OBJECTS)
 	@echo "#" $(NAME) $(GOAL) ": cc" $(@F)
 ifneq ($(OSSFUZZ),0)
 	@echo $(CXX) $(LIB_FUZZING_ENGINE) $(LINK_OPTIONS) $(OBJECTS) $(LIBRARIES) -o $@
-	$(CC) $(LIB_FUZZING_ENGINE) $(LINK_OPTIONS) $(OBJECTS) $(LIBRARIES) -o $@
+	$(CXX) $(LIB_FUZZING_ENGINE) $(LINK_OPTIONS) $(OBJECTS) $(LIBRARIES) -o $@
 else
 		$(CC) $(LINK_OPTIONS) $(OBJECTS) $(LIBRARIES) -o $@
 endif


### PR DESCRIPTION
This PR should only modify oss-fuzz builds (when `OSSFUZZ` is set) and fixes coverage builds. 

Debug build C options are mixed with oss-fuzz injected ones. This can cause issues particularly with coverage builds as flags can clash -- consequently coverage reports do not show correct figures. 

`OSSFUZZ` builds should have all the necessary options injected via `CFLAGS` and `CXXFLAGS`, so we only use those. 