### PR TITLE
Add TextDecoder and TextEncoder type definition

### DIFF
--- a/examples/manifest_typings.json
+++ b/examples/manifest_typings.json
@@ -21,6 +21,9 @@
 		"piu/*": [
 			"$(TYPINGS)/piu/*"
 		],
+		"text/*": [
+			"$(TYPINGS)/text/*"
+		],
 		"embedded:provider/*": [
 			"$(TYPINGS)/embedded_provider/*"
 		],

--- a/typings/text/decoder.d.ts
+++ b/typings/text/decoder.d.ts
@@ -1,0 +1,46 @@
+/*
+* Copyright (c) 2022 Satoshi Tanaka
+*
+*   This file is part of the Moddable SDK Tools.
+*
+*   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   The Moddable SDK Tools is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+declare module "text/decoder" {
+  interface TextDecoderOptions {
+    fatal?: boolean;
+    ignoreBOM?: boolean;
+  }
+  interface TextDecodeOptions {
+    stream?: boolean;
+  }
+
+  interface TextDecoder extends TextDecoderCommon {
+    decode(input?: Uint8Array | ArrayBufferLike, options?: TextDecodeOptions): string;
+  }
+
+  var TextDecoder: {
+    prototype: TextDecoder;
+    new(label?: "utf-8", options?: TextDecoderOptions): TextDecoder;
+  };
+
+  interface TextDecoderCommon {
+    readonly encoding: string;
+    readonly fatal: boolean;
+    readonly ignoreBOM: boolean;
+  }
+
+  export { TextDecoder as default };
+}

--- a/typings/text/encoder.d.ts
+++ b/typings/text/encoder.d.ts
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2022 Satoshi Tanaka
+*
+*   This file is part of the Moddable SDK Tools.
+*
+*   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   The Moddable SDK Tools is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+declare module "text/encoder" {
+
+    interface TextEncoderEncodeIntoResult {
+        read?: number;
+        written?: number;
+    }
+    interface TextEncoder {
+        encode(input: string | number): Uint8Array;
+        encodeInto(source: string, destination: Uint8Array): TextEncoderEncodeIntoResult;
+    }
+
+    var TextEncoder: {
+        prototype: TextEncoder;
+        new(): TextEncoder;
+    };
+
+    export { TextEncoder as default };
+}

--- a/typings/text/encoder.d.ts
+++ b/typings/text/encoder.d.ts
@@ -21,8 +21,8 @@
 declare module "text/encoder" {
 
     interface TextEncoderEncodeIntoResult {
-        read?: number;
-        written?: number;
+        read: number;
+        written: number;
     }
     interface TextEncoder {
         encode(input: string | number): Uint8Array;

--- a/typings/text/encoder.d.ts
+++ b/typings/text/encoder.d.ts
@@ -25,7 +25,7 @@ declare module "text/encoder" {
         written: number;
     }
     interface TextEncoder {
-        encode(input: string | number): Uint8Array;
+        encode(input: string): Uint8Array;
         encodeInto(source: string, destination: Uint8Array): TextEncoderEncodeIntoResult;
     }
 


### PR DESCRIPTION
I made this PR based on [@types/web](https://www.npmjs.com/package/@types/web), but modified to match [test of Moddable SDK](https://github.com/Moddable-OpenSource/moddable/tree/public/tests/modules/data/text) .