### PR TITLE
Improve typings for `AudioOut` and `Resource`

### DIFF
--- a/typings/Resource.d.ts
+++ b/typings/Resource.d.ts
@@ -22,6 +22,7 @@ declare module "Resource" {
   class Resource extends HostBuffer {
     constructor(path: string);
     slice(begin: number, end?: number): ArrayBuffer;
+    slice(begin: number, end?: number, copy?: boolean): HostBuffer;
     static exists(path: string): boolean;
   }
 

--- a/typings/pins/audioout.d.ts
+++ b/typings/pins/audioout.d.ts
@@ -67,7 +67,7 @@ declare module 'pins/audioout' {
     public static readonly Silence: MixerSilence
   }
 
-  type AudioOutCallback = (value?: number) => void
+  type AudioOutCallback = (value: number) => void
   class AudioOut extends Mixer {
       start(): void
       stop(): void

--- a/typings/pins/audioout.d.ts
+++ b/typings/pins/audioout.d.ts
@@ -55,6 +55,8 @@ declare module 'pins/audioout' {
     public enqueue(stream: number, kind: MixerSilence, samples: number): void
     
     public mix(samplesNeeded: number): HostBuffer
+
+    public length(stream: number): number
   
     public static readonly Samples: MixerSamples
     public static readonly Flush: MixerFlush

--- a/typings/pins/audioout.d.ts
+++ b/typings/pins/audioout.d.ts
@@ -65,10 +65,12 @@ declare module 'pins/audioout' {
     public static readonly Silence: MixerSilence
   }
 
+  type AudioOutCallback = (value?: number) => void
   class AudioOut extends Mixer {
       start(): void
       stop(): void
-      callback(): void
+      callback: AudioOutCallback
+      callbacks: AudioOutCallback[]
       readonly mix: undefined
   }
   export { AudioOut as default }


### PR DESCRIPTION
Here I updated typings for `AudioOut` and `Resource`.

- `callbacks` property of `AudioOut` for setting callback functions for each stream
- `length` member function of `AudioOut` that returns the number of queued items
- `copy` option of `Resource#slice` to get `HostBuffer` object

afaik latter two are undocumented. I found them in the [wavstreamer](https://github.com/phoddie/soundstream/blob/main/http-stream/wavstreamer.js) sample implementation.