### PR TITLE
mcconfig: fix -x support for Windows platforms

### DIFF
--- a/tools/mcconfig/nmake.esp.mk
+++ b/tools/mcconfig/nmake.esp.mk
@@ -54,7 +54,7 @@ UPLOAD_RESET = nodemcu
 UPLOAD_VERB = -v
 !ENDIF
 
-START_SERIAL2XSBUG= $(BUILD_DIR)\bin\win\release\serial2xsbug $(UPLOAD_PORT) $(DEBUGGER_SPEED) 8N1 -elf $(TMP_DIR)\main.elf
+START_SERIAL2XSBUG= set XSBUG_PORT=$(XSBUG_PORT) && set XSBUG_HOST=$(XSBUG_HOST) && $(BUILD_DIR)\bin\win\release\serial2xsbug $(UPLOAD_PORT) $(DEBUGGER_SPEED) 8N1 -elf $(TMP_DIR)\main.elf
 START_XSBUG= tasklist /nh /fi "imagename eq xsbug.exe" | find /i "xsbug.exe" > nul || (start $(BUILD_DIR)\bin\win\release\xsbug.exe)
 KILL_SERIAL2XSBUG= -tasklist /nh /fi "imagename eq serial2xsbug.exe" | (find /i "serial2xsbug.exe" > nul) && taskkill /f /t /im "serial2xsbug.exe" >nul 2>&1
 

--- a/tools/mcconfig/nmake.esp32.mk
+++ b/tools/mcconfig/nmake.esp32.mk
@@ -102,7 +102,7 @@ START_XSBUG= tasklist /nh /fi "imagename eq xsbug.exe" | find /i "xsbug.exe" > n
 BUILD_CMD = python %IDF_PATH%\tools\idf.py $(IDF_PY_LOG_FLAG) build -D mxDebug=1 -D INSTRUMENT=$(INSTRUMENT) -D TMP_DIR="$(TMP_DIR)" -D SDKCONFIG_HEADER="$(SDKCONFIG_H)" -D CMAKE_MESSAGE_LOG_LEVEL=$(CMAKE_LOG_LEVEL) -D DEBUGGER_SPEED=$(DEBUGGER_SPEED) -D ESP32_SUBCLASS=$(ESP32_SUBCLASS)
 BUILD_MSG =
 DEPLOY_CMD = python %IDF_PATH%\tools\idf.py $(IDF_PY_LOG_FLAG) $(PORT_COMMAND) -b $(UPLOAD_SPEED) flash -D mxDebug=1 -D INSTRUMENT=$(INSTRUMENT) -D TMP_DIR="$(TMP_DIR)" -D SDKCONFIG_HEADER="$(SDKCONFIG_H)" -D CMAKE_MESSAGE_LOG_LEVEL=$(CMAKE_LOG_LEVEL) -D DEBUGGER_SPEED=$(DEBUGGER_SPEED) -D ESP32_SUBCLASS=$(ESP32_SUBCLASS)
-START_SERIAL2XSBUG = echo Launching app... & echo Type Ctrl-C twice after debugging app. & $(BUILD_DIR)\bin\win\release\serial2xsbug $(PORT_TO_USE) $(DEBUGGER_SPEED) 8N1
+START_SERIAL2XSBUG = echo Launching app... & echo Type Ctrl-C twice after debugging app. & set XSBUG_PORT=$(XSBUG_PORT) && set XSBUG_HOST=$(XSBUG_HOST) && $(BUILD_DIR)\bin\win\release\serial2xsbug $(PORT_TO_USE) $(DEBUGGER_SPEED) 8N1
 !ELSE
 KILL_SERIAL2XSBUG= -tasklist /nh /fi "imagename eq serial2xsbug.exe" | (find /i "serial2xsbug.exe" > nul) && taskkill /f /t /im "serial2xsbug.exe" >nul 2>&1
 START_XSBUG=
@@ -429,8 +429,7 @@ debug: precursor
 	-copy $(BLD_DIR)\bootloader\bootloader.bin $(BIN_DIR)\.
 	-copy $(PARTITIONS_PATH) $(BIN_DIR)\.
 	-copy $(BLD_DIR)\ota_data_initial.bin $(BIN_DIR)\.
-	(@echo Launching app. Type Ctrl-C twice after debugging app to close serial2xsbug...)
-	$(BUILD_DIR)\bin\win\release\serial2xsbug $(PORT_TO_USE) $(DEBUGGER_SPEED) 8N1
+	$(START_SERIAL2XSBUG)
 
 release: precursor
 	if exist $(BLD_DIR)\xs_esp32.elf del $(BLD_DIR)\xs_esp32.elf


### PR DESCRIPTION
This PR adds some missing host / port definitions to mcconfig's makefiles for the Windows platform, thus fixing command line parameter `-x` support.

This change addresses (only) the targets `esp` and `esp32` as for others (e.g. `pico`) currently no makefile dedicated to the Windows platform is / seems to be defined.