### PR TITLE
Add ResourceStreamer

### DIFF
--- a/examples/pins/audioout/resource-stream/main.js
+++ b/examples/pins/audioout/resource-stream/main.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK.
+ * 
+ *   This work is licensed under the
+ *       Creative Commons Attribution 4.0 International License.
+ *   To view a copy of this license, visit
+ *       <http://creativecommons.org/licenses/by/4.0>.
+ *   or send a letter to Creative Commons, PO Box 1866,
+ *   Mountain View, CA 94042, USA.
+ *
+ */
+
+import AudioOut from "pins/audioout"
+import ResourceStreamer from "resourcestreamer";
+import Timer from "timer";
+
+function calculatePower(samplea) @ "xs_calculatePower";
+
+const audio = new AudioOut({});
+let streamer
+
+async function stream() {
+	return new Promise((resolve, reject) => {
+		if (streamer != null) {
+			reject(new Error("already playing"));
+			return
+		}
+		streamer = new ResourceStreamer({
+		path: "bflatmajor.maud",
+		audio: {
+			out: audio,
+			stream: 0,
+			sampleRate: 11025
+		},
+		onPlayed(buffer) {
+			const power = calculatePower(buffer);
+			trace("power " + Math.round(power) + "\n");
+		},
+		onReady(state) {
+			trace(`Ready: ${state}\n`);
+			if (state)
+				audio.start();
+			else
+				audio.stop();
+		},
+		onError(e) {
+			trace("ERROR: ", e, "\n");
+			streamer = null
+			reject(new Error("unknown error occured"))
+		},
+		onDone() {
+			trace("DONE\n");
+			streamer.close()
+			streamer = null
+			resolve()
+		}
+	});
+})
+}
+
+(async function main() {
+	let count = 0
+	while (true){
+		trace(`play: ${count++}\n`)
+		let willPlay = stream();
+		let willFail = stream().catch(e => {trace(`error: ${e.message}\n`)}) // error: already playing
+		await Promise.allSettled([willPlay, willFail])
+		Timer.delay(2000)
+	}
+})()

--- a/examples/pins/audioout/resource-stream/manifest.json
+++ b/examples/pins/audioout/resource-stream/manifest.json
@@ -1,0 +1,14 @@
+{
+	"include": [
+		"./manifest_streamer.json"
+	],
+	"resources": {
+		"*": "../../../assets/sounds/bflatmajor"
+	},
+	"modules": {
+		"*": [
+			"./main",
+			"../http-stream/calculatePower"
+		]
+	}
+}

--- a/examples/pins/audioout/resource-stream/manifest_streamer.json
+++ b/examples/pins/audioout/resource-stream/manifest_streamer.json
@@ -1,0 +1,46 @@
+{
+	"include": [
+		"$(MODDABLE)/examples/manifest_base.json",
+		"$(MODDABLE)/modules/io/manifest.json"
+	],
+	"modules": {
+		"*": [
+			"./resourcestreamer",
+			"../http-stream/calculatePower"
+		],
+		"pins/*": [
+			"$(MODULES)/pins/i2s/*"
+		]
+	},
+	"preload": [
+		"resourcestreamer"
+	],
+	"defines": {
+		"audioOut": {
+			"queueLength": 24
+		}
+	},
+	"config": {
+		"startupSound": false
+	},
+	"platforms": {
+		"mac": {
+			"defines": {
+				"audioOut": {
+					"bitsPerSample": 16,
+					"numChannels": 1,
+					"sampleRate": 11025
+				}
+			}
+		},
+		"esp32": {
+			"defines": {
+				"audioOut": {
+					"bitsPerSample": 16,
+					"numChannels": 1,
+					"sampleRate": 11025
+				}
+			}
+		}
+	}
+}

--- a/examples/pins/audioout/resource-stream/manifest_streamer.json
+++ b/examples/pins/audioout/resource-stream/manifest_streamer.json
@@ -5,8 +5,7 @@
 	],
 	"modules": {
 		"*": [
-			"./resourcestreamer",
-			"../http-stream/calculatePower"
+			"./resourcestreamer"
 		],
 		"pins/*": [
 			"$(MODULES)/pins/i2s/*"

--- a/examples/pins/audioout/resource-stream/resourcestreamer.js
+++ b/examples/pins/audioout/resource-stream/resourcestreamer.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022  Shinya Ishikawa.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+	Streaming from resource
+*/
+import Resource from "Resource";
+
+class ResourceStreamer {
+  #audio;
+  #stream;
+  #playing = [];
+  #bytesQueued = 0;
+  #targetBytesQueued;
+  #bytesPerSample = 2;
+  #bytesPerBlock;
+  #callbacks = [];
+  #resource;
+
+  constructor(options) {
+    this.#resource = new Resource(options.path);
+    this.#resource.position = 12; // skip maud header
+    const sampleRate = options.audio.sampleRate;
+    this.#targetBytesQueued = sampleRate * this.#bytesPerSample;
+    this.#bytesPerBlock = Math.idiv(this.#targetBytesQueued, 8);
+    if (this.#bytesPerBlock % this.#bytesPerSample)
+      throw new Error("invalid bytesPerBlock");
+
+    if (options.onPlayed) this.#callbacks.onPlayed = options.onPlayed;
+    if (options.onError) this.#callbacks.onError = options.onError;
+    if (options.onDone) this.#callbacks.onDone = options.onDone;
+
+    const audio = options.audio.out;
+    this.#audio = audio;
+    this.#stream = options.audio.stream ?? 0;
+    audio.callbacks ??= [];
+    audio.callbacks[this.#stream] = (bytes) => {
+      if (!bytes) {
+        this.#callbacks.onDone?.();
+        return;
+      }
+
+      this.#bytesQueued -= bytes;
+      let played = this.#playing.shift();
+      this.#callbacks.onPlayed?.(played);
+      played = undefined;
+      this.#fillQueue();
+    };
+    this.#fillQueue();
+    this.#audio.start();
+  }
+  close() {
+    this.#audio.enqueue(this.#stream, this.#audio.constructor.Flush);
+    this.#audio.callbacks[this.#stream] = null;
+
+    this.#audio = this.#playing = undefined;
+  }
+  #fillQueue() {
+    while (
+      this.#bytesQueued < this.#targetBytesQueued &&
+      this.#resource.position < this.#resource.byteLength &&
+      this.#audio.length(this.#stream) >= 2
+    ) {
+      const use = Math.min(
+        this.#targetBytesQueued - this.#bytesQueued,
+        this.#bytesPerBlock
+      );
+      const slice = this.#resource.slice(
+        this.#resource.position,
+        this.#resource.position + use,
+        false
+      );
+      this.#resource.position += slice.byteLength;
+      this.#audio.enqueue(
+        this.#stream,
+        this.#audio.constructor.RawSamples,
+        slice,
+        1,
+        0,
+        slice.byteLength / this.#bytesPerSample
+      );
+      this.#audio.enqueue(
+        this.#stream,
+        this.#audio.constructor.Callback,
+        slice.byteLength
+      );
+      this.#bytesQueued += slice.byteLength;
+      this.#playing.push(slice);
+      if (this.#resource.position === this.#resource.byteLength)
+        this.#audio.enqueue(0, this.#audio.constructor.Callback, 0);
+    }
+  }
+}
+
+export default ResourceStreamer;

--- a/examples/pins/audioout/resource-stream/resourcestreamer.js
+++ b/examples/pins/audioout/resource-stream/resourcestreamer.js
@@ -19,8 +19,11 @@
  */
 
 /*
-	Streaming from resource
-*/
+ * Streaming from local audio samples.
+ * 
+ *   Streaming is not needed for playback: the full resource could be queued.
+ *   ResourceStreamer is convenient for interoperability with other Streamer classes that have onPlayed callback, etc.
+ */
 import Resource from "Resource";
 
 class ResourceStreamer {


### PR DESCRIPTION
I implemented `ResourceStreamer` class by adding `WavStreamer` compatible I/F to @phoddie 's [`resource-stream`  example](https://github.com/phoddie/soundstream/tree/main/resource-stream).

This is a local resource version of [`WavStreamer`](https://github.com/Moddable-OpenSource/moddable/blob/public/examples/pins/audioout/http-stream/wavstreamer.js).
Streaming is not necessary for local audio playback, but I think `ResourceStreamer` is convenient for interoperability with other streaming classes that have `onPlayed` callback and etc.

https://github.com/phoddie/soundstream/issues/1