### PR TITLE
Add metering in oss-fuzz harness

### DIFF
--- a/xs/makefiles/lin/xst.mk
+++ b/xs/makefiles/lin/xst.mk
@@ -76,7 +76,10 @@ ifeq ($(GOAL),debug)
 		C_OPTIONS += -DFUZZING=1
 	endif
 	ifneq ($(OSSFUZZ),0)
-		C_OPTIONS += -DOSSFUZZ=1  -DmxMetering=1
+		C_OPTIONS += -DOSSFUZZ=1 -DmxMetering=1
+		ifneq ($(FUZZ_METER),0)
+			C_OPTIONS += -DmxFuzzMeter=$(FUZZ_METER)
+		endif
 		C_OPTIONS += $(CFLAGS)
 		LINK_OPTIONS += $(CXXFLAGS)
 		ifneq ($(OSSFUZZ_JSONPARSE),0)

--- a/xs/makefiles/lin/xst.mk
+++ b/xs/makefiles/lin/xst.mk
@@ -76,7 +76,7 @@ ifeq ($(GOAL),debug)
 		C_OPTIONS += -DFUZZING=1
 	endif
 	ifneq ($(OSSFUZZ),0)
-		C_OPTIONS += -DOSSFUZZ=1
+		C_OPTIONS += -DOSSFUZZ=1  -DmxMetering=1
 		C_OPTIONS += $(CFLAGS)
 		LINK_OPTIONS += $(CXXFLAGS)
 		ifneq ($(OSSFUZZ_JSONPARSE),0)

--- a/xs/tools/xst.c
+++ b/xs/tools/xst.c
@@ -1883,8 +1883,15 @@ int fuzz(int argc, char* argv[])
 #if OSSFUZZ
 static xsBooleanValue xsWithinComputeLimit(xsMachine* machine, xsUnsignedValue index)
 {
-	// some test262 fail at 2147483800
-	if (index > 1000000) {
+	#ifdef mxFuzzMeter
+		static const xsUnsignedValue mxFuzzMeterLimit = mxFuzzMeter;
+	#elif
+		// highest rate for test262 corpus was 2147483800
+		static const xsUnsignedValue mxFuzzMeterLimit = 214748380;
+	#endif
+	// may be useful to print current index for debugging
+	// fprintf(stderr, "Current index: %u\n", index);
+	if (index > mxFuzzMeterLimit) {
 		fprintf(stderr, "Computation limits reached (index %u). Exiting...\n", index);
 		return 0;
 	}
@@ -1916,7 +1923,7 @@ int fuzz_oss(const uint8_t *Data, size_t script_size)
 	fxInitializeSharedCluster();
 	machine = xsCreateMachine(creation, "xst", NULL);
 
-	xsBeginMetering(machine, xsWithinComputeLimit, 10000);
+	xsBeginMetering(machine, xsWithinComputeLimit, 1);
 	{
 		xsBeginHost(machine);
 		{


### PR DESCRIPTION
This PR modifies the OSS-fuzz harness so that the XS metering limits execution. By exiting gracefully (rather than being interrupted by a timeout) when reaching a computation limit we avoid the fuzzer interpreting long-running test cases (infinite or near-infinite loops) as a bug.