### PR TITLE
example/io/tcp/mqtt: minor fixes

### DIFF
--- a/examples/io/tcp/mqtt/mqtt.js
+++ b/examples/io/tcp/mqtt/mqtt.js
@@ -69,7 +69,7 @@ export class Client {
 		let will = null;
 		if (options) {
 			if ("clientId" in options)
-				id = clientId
+				id = options.clientId
 			if ("keepalive" in options)
 				keepalive = 1000 * options.keepalive
 			if ("password" in options)
@@ -85,9 +85,9 @@ export class Client {
 				};
 			}
 			if ("reconnectPeriod" in options)
-				this.#reconnectPeriod = reconnectPeriod;
+				this.#reconnectPeriod = options.reconnectPeriod
 			if ("resubscribe" in options)
-				this.#resubscribe = resubscribe;
+				this.#resubscribe = options.resubscribe
 		}
 		this.#options = {
 			...device.network.mqtt,

--- a/examples/io/tcp/mqttclient/mqttclient.js
+++ b/examples/io/tcp/mqttclient/mqttclient.js
@@ -712,7 +712,7 @@ class MQTTClient {
 		if ((options.last + (interval + (interval >> 1))) < now)
 			return void this.#onError("time out"); // no response in too long
 
-		for (let i = 0, queue = this.#queue, length = queue.length; i < length; i++) {
+		for (let i = 0, queue = this.#options.pending, length = queue.length; i < length; i++) {
 			if (queue[i].keepalive && (MQTTClient.PINGREQ === queue[i].operation))
 				return void this.#onError("time out"); // unsent keepalive ping, exit
 		}


### PR DESCRIPTION
One commit fixes the options processing in mqtt.js
The other commit fixes the checking of the queue for keepalive pings in mqttclient.js

I'd like to also note that the keepalive algorithm in mqttclient.js is not according to the MQTT spec. Specifically, the connect message establishes a keepalive value. According to the 3.1.1 spec:

> The Keep Alive is [...] the maximum time interval that is permitted to elapse between the point at which the Client finishes transmitting one Control Packet and the point it starts sending the next. [MQTT-3.1.2-23].

Thus the time is about mqttclient _sending_ packets. However, the code in `#keepalive` looks at `this.#options.last` which is about when the last data was _received_ from the server. Thus there is a mismatch. For example, if the client does not publish anything but keeps receiving a stream of incoming messages then the algorithm will not send any pings and the server will disconnect it. It's not a big issue but it should be fixed at some point (IMO).