### PR TITLE
Pulse-width is now available for major models of M5Stack products.

### DIFF
--- a/build/devices/esp32/targets/m5stack/host/provider.js
+++ b/build/devices/esp32/targets/m5stack/host/provider.js
@@ -27,6 +27,7 @@ import PWM from "embedded:io/pwm";
 import Serial from "embedded:io/serial";
 import SMBus from "embedded:io/smbus";
 import SPI from "embedded:io/spi";
+import PulseWidth from "embedded:io/pulsewidth";
 
 const device = {
 	I2C: {
@@ -59,7 +60,7 @@ const device = {
 			pin: 35
 		}
 	},
-	io: {Analog, Digital, DigitalBank, I2C, PulseCount, PWM, Serial, SMBus, SPI},
+	io: {Analog, Digital, DigitalBank, I2C, PulseCount,PulseWidth, PWM, Serial, SMBus, SPI},
 	pin: {
 		button: 38,
 		led: 2,

--- a/build/devices/esp32/targets/m5stack_core2/host/provider.js
+++ b/build/devices/esp32/targets/m5stack_core2/host/provider.js
@@ -27,6 +27,7 @@ import PWM from "embedded:io/pwm";
 import Serial from "embedded:io/serial";
 import SMBus from "embedded:io/smbus";
 import SPI from "embedded:io/spi";
+import PulseWidth from "embedded:io/pulsewidth";
 
 const device = {
 	I2C: {
@@ -64,7 +65,7 @@ const device = {
 			pin: 35
 		}
 	},
-	io: {Analog, Digital, DigitalBank, I2C, PulseCount, PWM, Serial, SMBus, SPI},
+	io: {Analog, Digital, DigitalBank, I2C, PulseCount, PulseWidth, PWM, Serial, SMBus, SPI},
 	pin: {
 		displayDC: 15,
 		displaySelect: 5

--- a/build/devices/esp32/targets/m5stick_cplus/host/provider.js
+++ b/build/devices/esp32/targets/m5stick_cplus/host/provider.js
@@ -27,6 +27,7 @@ import PWM from "embedded:io/pwm";
 import Serial from "embedded:io/serial";
 import SMBus from "embedded:io/smbus";
 import SPI from "embedded:io/spi";
+import PulseWidth from "embedded:io/pulsewidth";
 
 const device = {
 	I2C: {
@@ -68,7 +69,7 @@ const device = {
 			pin: 36
 		}
 	},
-	io: {Analog, Digital, DigitalBank, I2C, PulseCount, PWM, Serial, SMBus, SPI},
+	io: {Analog, Digital, DigitalBank, I2C, PulseCount, PulseWidth, PWM, Serial, SMBus, SPI},
 	pin: {
 		button: 37,
 		led: 10,


### PR DESCRIPTION
M5Stack basic, Core2 and StickC plus are set to use PulseWidth.