### PR TITLE
Fail path

### DIFF
--- a/tools/mcconfig/make.esp32.mk
+++ b/tools/mcconfig/make.esp32.mk
@@ -389,8 +389,8 @@ ifeq ($(DEBUG),1)
 		DO_XSBUG = $(shell nohup $(BUILD_DIR)/bin/lin/release/xsbug > /dev/null 2>&1 &)
 		ifeq ($(USE_USB),1)
 #			DO_LAUNCH = bash -c "serial2xsbug $(USB_VENDOR_ID):$(USB_PRODUCT_ID) $(DEBUGGER_SPEED) 8N1"
-			DO_LAUNCH = bash -c "PATH=$(PLATFORM_DIR)/config:$(PATH) ; connectToXsbugLinux $(USB_VENDOR_ID) $(USB_PRODUCT_ID) $(XSBUG_LOG)"
-			PROGRAMMING_MODE = bash -c "PATH=$(PLATFORM_DIR)/config:$(PATH) ; programmingModeLinux $(PROGRAMMING_VID) $(PROGRAMMING_PID) $(XSBUG_LOG)"
+			DO_LAUNCH = bash -c "PATH=$(PLATFORM_DIR)/config:\"$(PATH) \""; connectToXsbugLinux $(USB_VENDOR_ID) $(USB_PRODUCT_ID) $(XSBUG_LOG)"
+			PROGRAMMING_MODE = bash -c "PATH=$(PLATFORM_DIR)/config:\"$(PATH)\"" ; programmingModeLinux $(PROGRAMMING_VID) $(PROGRAMMING_PID) $(XSBUG_LOG)"
 		else
 			LOG_LAUNCH = bash -c \"XSBUG_PORT=$(XSBUG_PORT) XSBUG_HOST=$(XSBUG_HOST) serial2xsbug $(SERIAL2XSBUG_PORT) $(DEBUGGER_SPEED) 8N1\"
 

--- a/tools/mcconfig/make.esp32.mk
+++ b/tools/mcconfig/make.esp32.mk
@@ -389,8 +389,8 @@ ifeq ($(DEBUG),1)
 		DO_XSBUG = $(shell nohup $(BUILD_DIR)/bin/lin/release/xsbug > /dev/null 2>&1 &)
 		ifeq ($(USE_USB),1)
 #			DO_LAUNCH = bash -c "serial2xsbug $(USB_VENDOR_ID):$(USB_PRODUCT_ID) $(DEBUGGER_SPEED) 8N1"
-			DO_LAUNCH = bash -c "PATH=$(PLATFORM_DIR)/config:\"$(PATH) \""; connectToXsbugLinux $(USB_VENDOR_ID) $(USB_PRODUCT_ID) $(XSBUG_LOG)"
-			PROGRAMMING_MODE = bash -c "PATH=$(PLATFORM_DIR)/config:\"$(PATH)\"" ; programmingModeLinux $(PROGRAMMING_VID) $(PROGRAMMING_PID) $(XSBUG_LOG)"
+			DO_LAUNCH = bash -c "PATH=\"$(PLATFORM_DIR)/config:$(PATH)\"; connectToXsbugLinux $(USB_VENDOR_ID) $(USB_PRODUCT_ID) $(XSBUG_LOG)"
+			PROGRAMMING_MODE = bash -c "PATH=\"$(PLATFORM_DIR)/config:$(PATH)\"; programmingModeLinux $(PROGRAMMING_VID) $(PROGRAMMING_PID) $(XSBUG_LOG)"
 		else
 			LOG_LAUNCH = bash -c \"XSBUG_PORT=$(XSBUG_PORT) XSBUG_HOST=$(XSBUG_HOST) serial2xsbug $(SERIAL2XSBUG_PORT) $(DEBUGGER_SPEED) 8N1\"
 


### PR DESCRIPTION
ixed errors due to spaces in PATH when compiling esp32 in WSL2 environment on Windows.

```
Project build complete. To flash, run this command:
/home/user/.espressif/python_env/idf4.4_py3.10_env/bin/python ../../../../../../../../../esp32/esp-idf/components/esptool_py/esptool/esptool.py -p (PORT) -b 460800 --before default_reset --after hard_reset --chip esp32s3  write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 build/bootloader/bootloader.bin 0x8000 build/partition_table/partition-table.bin 0x10000 build/xs_esp32.bin
or run 'idf.py -p (PORT) flash'
bash: -c: line 1: syntax error near unexpected token `('
bash: -c: line 1: `PATH=/home/user/Project/moddable/build/devices/esp32/config:/home/user/esp32/esp-idf/components/esptool_py/esptool:/home/user/esp32/esp-idf/components/espcoredump:/home/user/esp32/esp-idf/components/partition_table:/home/user/esp32/esp-idf/components/app_update:/home/user/.espressif/tools/xtensa-esp32-elf/esp-2021r2-patch5-8.4.0/xtensa-esp32-elf/bin:/home/user/.espressif/tools/xtensa-esp32s2-elf/esp-2021r2-patch5-8.4.0/xtensa-esp32s2-elf/bin:/home/user/.espressif/tools/xtensa-esp32s3-elf/esp-2021r2-patch5-8.4.0/xtensa-esp32s3-elf/bin:/home/user/.espressif/tools/riscv32-esp-elf/esp-2021r2-patch5-8.4.0/riscv32-esp-elf/bin:/home/user/.espressif/tools/esp32ulp-elf/2.35_20220830/esp32ulp-elf/bin:/home/user/.espressif/tools/openocd-esp32/v0.11.0-esp32-20220706/openocd-esp32/bin:/home/user/.espressif/python_env/idf4.4_py3.10_env/bin:/home/user/esp32/esp-idf/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/mnt/c/Python311/Scripts/:/mnt/c/Python311/:/mnt/c/Python39/Scripts/:/mnt/c/Python39/:/mnt/c/Windows/system32:/mnt/c/Windows:/mnt/c/Windows/System32/Wbem:/mnt/c/Windows/System32/WindowsPowerShell/v1.0/:/mnt/c/Windows/System32/OpenSSH/:/mnt/c/Program Files (x86)/NVIDIA Corporation/PhysX/Common:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/ProgramData/chocolatey/bin:/mnt/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/MSBuild/15.0/Bin:/mnt/c/Program Files/dotnet/:/mnt/c/Program Files (x86)/Brackets/command:/mnt/c/Users/tauchi/AppData/Local/Android/Sdk:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/Git/cmd:/mnt/c/Program Files/nodejs/:/mnt/c/Program Files/usbipd-win/:/mnt/c/Users/tauchi/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/tauchi/AppData/Local/Programs/Microsoft VS Code/bin:/mnt/c/Users/tauchi/.dotnet/tools:/mnt/c/platform-tools:/mnt/d/github/moddable/build/bin/win/release:/snap/bin:/home/user/Project/moddable/build/bin/lin/release ; programmingModeLinux 303a 1001 '
make: *** [/home/user/Project/moddable/build/tmp/esp32/atoms3/debug/helloworld/makefile:590: all] Error 2
```