### PR TITLE
Esp32s3

### DIFF
--- a/build/devices/esp32/config/findUSBLinux
+++ b/build/devices/esp32/config/findUSBLinux
@@ -11,11 +11,22 @@ for sysdevpath in $(find /sys/bus/usb/devices/usb*/ -name dev); do
         syspath="${sysdevpath%/dev}"
         devname="$(udevadm info -q name -p $syspath)"
         [[ "$devname" == "bus/"* ]] && exit
+        if [[ "$syspath" == "/sys/bus/usb/devices/usb"?"/"?"-"?"/"?"-"?":1.0/"* ]]
+        then
+#               echo "wsl"
+                syspath2=${syspath%/*/*}
+        eval "$(udevadm info -q property --export -p $syspath2)"
+#       [[ "$ID_VENDOR_ID" != "$1" || "$ID_MODEL_ID" != "$2" ]] && exit
+        [[ "$PRODUCT" != "$1/$2"* ]] && exit
+        [[ "$3" != "" && "$DRIVER" != "$3" ]] && exit
+        echo "/dev/$devname"
+        else
 # echo "$(udevadm info -q property --export -p $syspath)"
         eval "$(udevadm info -q property --export -p $syspath)"
 	[[ "$ID_VENDOR_ID" != "$1" || "$ID_MODEL_ID" != "$2" ]] && exit
 	[[ "$3" != "" && "$ID_USB_DRIVER" != "$3" ]] && exit
         echo "/dev/$devname"
+	fi
     )
 done
 

--- a/tools/mcconfig/make.esp32.mk
+++ b/tools/mcconfig/make.esp32.mk
@@ -389,8 +389,8 @@ ifeq ($(DEBUG),1)
 		DO_XSBUG = $(shell nohup $(BUILD_DIR)/bin/lin/release/xsbug > /dev/null 2>&1 &)
 		ifeq ($(USE_USB),1)
 #			DO_LAUNCH = bash -c "serial2xsbug $(USB_VENDOR_ID):$(USB_PRODUCT_ID) $(DEBUGGER_SPEED) 8N1"
-			DO_LAUNCH = bash -c "PATH=$(PLATFORM_DIR)/config:$(PATH) ; connectToXsbugLinux $(USB_VENDOR_ID) $(USB_PRODUCT_ID) $(XSBUG_LOG)"
-			PROGRAMMING_MODE = bash -c "PATH=$(PLATFORM_DIR)/config:$(PATH) ; programmingModeLinux $(PROGRAMMING_VID) $(PROGRAMMING_PID) $(XSBUG_LOG)"
+			DO_LAUNCH = bash -c "PATH=$(PLATFORM_DIR)/config:\"$(PATH) \""; connectToXsbugLinux $(USB_VENDOR_ID) $(USB_PRODUCT_ID) $(XSBUG_LOG)"
+			PROGRAMMING_MODE = bash -c "PATH=$(PLATFORM_DIR)/config:\"$(PATH)\"" ; programmingModeLinux $(PROGRAMMING_VID) $(PROGRAMMING_PID) $(XSBUG_LOG)"
 		else
 			LOG_LAUNCH = bash -c \"XSBUG_PORT=$(XSBUG_PORT) XSBUG_HOST=$(XSBUG_HOST) serial2xsbug $(SERIAL2XSBUG_PORT) $(DEBUGGER_SPEED) 8N1\"
 

--- a/tools/mcconfig/make.esp32.mk
+++ b/tools/mcconfig/make.esp32.mk
@@ -389,8 +389,8 @@ ifeq ($(DEBUG),1)
 		DO_XSBUG = $(shell nohup $(BUILD_DIR)/bin/lin/release/xsbug > /dev/null 2>&1 &)
 		ifeq ($(USE_USB),1)
 #			DO_LAUNCH = bash -c "serial2xsbug $(USB_VENDOR_ID):$(USB_PRODUCT_ID) $(DEBUGGER_SPEED) 8N1"
-			DO_LAUNCH = bash -c "PATH=$(PLATFORM_DIR)/config:\"$(PATH) \""; connectToXsbugLinux $(USB_VENDOR_ID) $(USB_PRODUCT_ID) $(XSBUG_LOG)"
-			PROGRAMMING_MODE = bash -c "PATH=$(PLATFORM_DIR)/config:\"$(PATH)\"" ; programmingModeLinux $(PROGRAMMING_VID) $(PROGRAMMING_PID) $(XSBUG_LOG)"
+			DO_LAUNCH = bash -c "PATH=\"$(PLATFORM_DIR)/config:$(PATH)\"; connectToXsbugLinux $(USB_VENDOR_ID) $(USB_PRODUCT_ID) $(XSBUG_LOG)"
+			PROGRAMMING_MODE = bash -c "PATH=\"$(PLATFORM_DIR)/config:$(PATH)\"; programmingModeLinux $(PROGRAMMING_VID) $(PROGRAMMING_PID) $(XSBUG_LOG)"
 		else
 			LOG_LAUNCH = bash -c \"XSBUG_PORT=$(XSBUG_PORT) XSBUG_HOST=$(XSBUG_HOST) serial2xsbug $(SERIAL2XSBUG_PORT) $(DEBUGGER_SPEED) 8N1\"
 


### PR DESCRIPTION
Make ESP32S3 available for Windows WSL2(+USBIPD).

DEBUG still doesn't work.

Advance preparation
Create a file on the WSL2 side.
`sudo vi /etc/udev/rules.d/50-myusb.rules`
Contents
```
KERNEL="ttyACM[0-9]*",MODE="0666"
```
Execute `sudo service udev restart` after creation

How to use (using AtomS3)
(WSL2 ubuntu)
```
cd examples/piu/balls
mcconfig -d -m -p esp32/atoms3
```
When prompted for boot mode
Put AtomS3 in Boot mode (press Reset for 3 seconds)
(Powershell (administrator))
Check the BUS-ID with `usbipd list`.
```usbipd wsl attach -b <BUS-ID>```
Press the reset button of AtomS3 when reset is requested.
Execute the `usbipd wsl attach -b <BUS-ID>` command again

thanks,