### PR TITLE
Add typing for securesocket

### DIFF
--- a/typings/file.d.ts
+++ b/typings/file.d.ts
@@ -35,7 +35,7 @@ declare module "file" {
     ): T extends typeof String ? string : InstanceType<T>;
 
     write(
-      value: ArrayBuffer | string,
+      value: ArrayBufferLike | ArrayBuffer | string,
       ...moreValues: (ArrayBuffer | string)[]
     ): void;
 

--- a/typings/pins/smbus.d.ts
+++ b/typings/pins/smbus.d.ts
@@ -36,7 +36,8 @@ declare module 'pins/smbus' {
     public read(count: number, buffer?: ArrayBuffer): void
     public write(first: any, ...valuesOrStop: (number | string | (number | string)[] | TypedArray | boolean)[]): void
     public readByte(register: number): number
-    public readWord(register: number): number
+    public readWord(register: number): number;
+    public readWord(register: number, bigEndian: boolean): number;
     public readBlock(register: number, count: number, buffer?: ArrayBuffer): Uint8Array
     public writeByte(register: number, value: number): void
     public writeWord(register: number, value: number): void

--- a/typings/securesocket.d.ts
+++ b/typings/securesocket.d.ts
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 2023 Richard Lea
+*
+*   This file is part of the Moddable SDK Tools.
+*
+*   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   The Moddable SDK Tools is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+declare module "securesocket" {
+    import { Socket } from "socket";
+
+    type WriteData = number | string | BufferLike;
+
+    export default class SecureSocket {
+        sock: Socket;
+
+        constructor(dict: { [k: string]: any });
+
+        read<T extends typeof String | typeof ArrayBuffer>(
+            type: T,
+            until?: number
+        ): T extends typeof String ? string : ArrayBuffer;
+        write(data: WriteData, ...moreData: WriteData[]): void;
+        close(): void;
+    }
+}


### PR DESCRIPTION
Let me push all missing types before push the commits drafted for synchronizing with DefinitelyType.