### PR TITLE
Extend wavstreamer request

### DIFF
--- a/examples/pins/audioout/http-stream/readme.md
+++ b/examples/pins/audioout/http-stream/readme.md
@@ -73,6 +73,7 @@ The options object may contain the following properties. The `http`, `host`, `pa
 - `host` - the HTTP host to connect to stream from
 - `port` - the remote port to connect to
 - `path` - the path of the HTTP resource to stream
+- `request` - an optional object that can contain additional [HTTP request](../../../../documentation/network/network.md#http-request) options such as `method`, `headers`, `body` etc. These options will be passed directly to the HTTP client. If not specified, default options will be used.
 - `audio.out` - the audio output instance to play the audio on
 - `audio.stream` - the stream number of the audio output to use to play the audio. Defaults to `0`.
 - `waveHeaderBytes` - the number of bytes to buffer before parsing the WAV header. Defaults to `512` (only supported by `WavStream`)

--- a/examples/pins/audioout/http-stream/wavstreamer.js
+++ b/examples/pins/audioout/http-stream/wavstreamer.js
@@ -75,6 +75,7 @@ class WavStreamer {
 			o.port = options.port; 
 		this.#http = new options.http.io(o);
 		this.#request = this.#http.request({
+			...options.request,
 			path: options.path,
 			onHeaders: (status, headers) => {
 				if (2 !== Math.idiv(status, 100)) {


### PR DESCRIPTION
This PR adds options to the WavStreamer class, allowing users to extend HTTP requests.

Use cases are provided in the Stack-chan repository.

https://github.com/meganetaaan/stack-chan/blob/cfc19242e6b13ebfa2ce1858bb9f5e96d1bc0c2d/firmware/stackchan/speech/tts-voicevox.ts#L87-L99

Some streaming servers accept requests other than GET (such as POST methods or requests for specific headers). By providing users with the ability to modify the request content, except for the properties required for the operation of WavStreamer, through callbacks such as onHeaders, this change enables WavStreamer to support such servers.