### PR TITLE
Update default TLS protocol version to 1.2

### DIFF
--- a/modules/crypt/ssl/ssl_constants.js
+++ b/modules/crypt/ssl/ssl_constants.js
@@ -62,7 +62,7 @@ export const NONE = 0;
 export const CBC = 1;
 export const GCM = 2;
 
-export const protocolVersion = (3 << 8) | 1;	// default protocol version
+export const protocolVersion = (3 << 8) | 3;	// default protocol version
 export const minProtocolVersion = (3 << 8) | 1;
 export const maxProtocolVersion = (3 << 8) | 3;
 


### PR DESCRIPTION
I encountered an error while developing my app:
```
You are using TLS version 1.0, 1.1 and/or 3DES cipher which are deprecated to improve the security posture of Azure AD.
```
It seems that many services are switching their TLS versions to 1.2. It could make sense to have TLS 1.2 as the default protocol version.

I have tested this in my app, and it works well.