### PR TITLE
Fix broken links

### DIFF
--- a/documentation/devices/esp32.md
+++ b/documentation/devices/esp32.md
@@ -66,7 +66,7 @@ The Moddable SDK supports many devices built on ESP32. The following table lists
 
 | Name | Platform identifier | Key features | Links |
 | :---: | :--- | :--- | :--- |
-| <img src="./../assets/devices/moddable-two.png" width=125><BR>Moddable Two | `esp32/moddable_two`<BR>`simulator/moddable_two` | **2.4" IPS display**<BR>240 x 320 QVGA<BR>16-bit color<BR>Capacitive touch<BR><BR>20 External pins  | <li>[Moddable Two developer guide](./moddable-two.md)</li><li>[Moddable product page](https://www.moddable.com/purchase.php)</li> |
+| <img src="./../assets/devices/moddable-two.png" width=125><BR>Moddable Two | `esp32/moddable_two`<BR>`simulator/moddable_two` | **2.4" IPS display**<BR>240 x 320 QVGA<BR>16-bit color<BR>Capacitive touch<BR><BR>20 External pins  | <li>[Moddable Two developer guide](./moddable-two.md)</li><li>[Moddable product page](https://www.moddable.com/purchase-cart.php)</li> |
 | ![ESP32](./../assets/devices/esp32.png)<BR>Node MCU ESP32 | `esp32/nodemcu` | | 
 | ![M5Stack](./../assets/devices/m5stack.png)<BR> M5Stack | `esp32/m5stack`<BR>`esp32/m5stack_core2` | **1.8" LCD display**<BR>320 x 240 QVGA<BR>16-bit color<BR><BR>Audio playback<BR>Accelerometer<BR>NeoPixels  | <li>[Product page](https://m5stack.com/collections/m5-core/products/basic-core-iot-development-kit)</li> |
 | ![M5Stack Fire](./../assets/devices/m5stack-fire.png)<BR>M5Stack Fire | `esp32/m5stack_fire` | **1.8" LCD display**<BR>320 x 240 QVGA<BR>16-bit color<BR><BR>Audio playback<BR>Accelerometer<BR>NeoPixels | <li>[Product page](https://m5stack.com/collections/m5-core/products/fire-iot-development-kit?variant=16804798169178)</li> |

--- a/documentation/devices/esp8266.md
+++ b/documentation/devices/esp8266.md
@@ -52,9 +52,9 @@ The Moddable SDK supports many devices built on ESP8266. The following table lis
 
 | Name | Platform identifier | Key feaures | Links |
 | :---: | :--- | :--- | :--- |
-| <img src="./../assets/devices/moddable-one.png" width=125><BR>Moddable One | `esp/moddable_one`<BR>`simulator/moddable_one` | **2.4" IPS display**<BR>240 x 320 QVGA<BR>16-bit color<BR>Capacitive touch<BR><BR>14 External pins | <li>[Moddable One  Developer Guide](./moddable-one.md)</li><li>[Moddable product page](https://www.moddable.com/purchase.php)</li> |
+| <img src="./../assets/devices/moddable-one.png" width=125><BR>Moddable One | `esp/moddable_one`<BR>`simulator/moddable_one` | **2.4" IPS display**<BR>240 x 320 QVGA<BR>16-bit color<BR>Capacitive touch<BR><BR>14 External pins | <li>[Moddable One  Developer Guide](./moddable-one.md)</li><li>[Moddable product page](https://www.moddable.com/purchase-cart.php)</li> |
 | <img src="./../assets/devices/esp8266.png" width=125><BR>Node MCU ESP8266 | `esp/nodemcu`<BR>`simulator/nodemcu` | | |
-| <img src="./../assets/devices/moddable-three.png" width=125><BR>Moddable Three | `esp/moddable_three`<BR>`simulator/moddable_three` |  **2.13" ePaper display**<BR>250 x 122 pixels<BR>1-bit black and white<BR><BR>11 External pins | <li>[Moddable Three Developer Guide](./moddable-three.md)</li><li>[Moddable product page](https://www.moddable.com/purchase.php)</li> |
+| <img src="./../assets/devices/moddable-three.png" width=125><BR>Moddable Three | `esp/moddable_three`<BR>`simulator/moddable_three` |  **2.13" ePaper display**<BR>250 x 122 pixels<BR>1-bit black and white<BR><BR>11 External pins | <li>[Moddable Three Developer Guide](./moddable-three.md)</li><li>[Moddable product page](https://www.moddable.com/purchase-cart.php)</li> |
 | <img src="https://www.moddable.com/images/moddable-zero-sm2.jpg" width=125><BR>Moddable Zero | `esp/moddable_zero` |  | <li>[Moddable Zero Developer Guide](./moddable-zero.md)</li> |
 
 We have also used many displays with the ESP8266 Node MCU board. The following table links to wiring guides and provides corresponding platform identifiers.

--- a/documentation/piu/expanding-keyboard.md
+++ b/documentation/piu/expanding-keyboard.md
@@ -2,7 +2,7 @@
 Copyright 2019 Moddable Tech, Inc.<BR>
 Revised: July 2, 2019
 
-The vertical and horizontal expanding keyboard modules implement touch screen keyboards for use with [Piu](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/piu/piu.md) on Moddable One and Moddable Two [products](https://www.moddable.com/product.php). The keys automatically expand when tapped, eliminating the need for a stylus. Both keyboards implement the same API. 
+The vertical and horizontal expanding keyboard modules implement touch screen keyboards for use with [Piu](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/piu/piu.md) on Moddable One and Moddable Two [products](https://www.moddable.com/hardware.php). The keys automatically expand when tapped, eliminating the need for a stylus. Both keyboards implement the same API. 
 
 - **Source code:** [`vertical/keyboard.js`](../../modules/input/expanding-keyboard/vertical/keyboard.js) [`horizontal/keyboard.js`](../../modules/input/expanding-keyboard/horizontal/keyboard.js)
 - **Relevant Examples:** [vertical-expanding-keyboard](../../examples/piu/vertical-expanding-keyboard/main.js) [horizontal-expanding-keyboard](../../examples/piu/horizontal-expanding-keyboard/main.js)

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ The Moddable SDK supports [many devices](./documentation/devices/esp8266.md#plat
 | <a href="./documentation/devices/moddable-one.md"><img src="./documentation/assets/devices/moddable-one.png" width=125></a><BR>Moddable One<sup>[[5](#footnotes2)]</sup> | <a href="./documentation/devices/esp8266.md"><img src="./documentation/assets/devices/esp8266.png" width=125></a><BR>Node MCU ESP8266<sup>[[6](#footnotes2)]</sup> | <a href="./documentation/devices/moddable-three.md"><img src="./documentation/assets/devices/moddable-three.png" width=125></a><BR>Moddable Three<sup>[[7](#footnotes2)]</sup>
 
 <a id="footnotes2"></a>
-> <sup>[5]</sup> *See also: [Moddable One Developer Guide](./documentation/devices/moddable-one.md), Moddable [product page](https://www.moddable.com/product)*<BR>
+> <sup>[5]</sup> *See also: [Moddable One Developer Guide](./documentation/devices/moddable-one.md), Moddable [product page](https://www.moddable.com/hardware)*<BR>
 <sup>[6]</sup> *See also: [Using the Moddable SDK with ESP8266](./documentation/devices/esp8266.md)*<BR>
 <sup>[7]</sup> *See also: [Moddable Three Developer Guide](./documentation/devices/moddable-three.md)*<BR>
 
@@ -109,7 +109,7 @@ The Moddable SDK supports [many devices](./documentation/devices/esp32.md#platfo
 | <a href="./documentation/devices/esp32.md#platforms">![M5Stack Fire](./documentation/assets/devices/m5stack-fire.png)</a><BR>M5Stack Fire | <a href="./documentation/devices/esp32.md#platforms">![M5Stick C](./documentation/assets/devices/m5stick-c.png)</a><BR>M5Stick C |  <a href="./documentation/devices/esp32.md#platforms">![M5Atom](./documentation/assets/devices/m5atom.png)</a><BR>M5Atom Matrix
 
 <a id="footnotes3"></a>
-> <sup>[8]</sup> *See also: [Moddable Two Developer Guide](./documentation/devices/moddable-two.md), Moddable [product page](https://www.moddable.com/product)*<BR>
+> <sup>[8]</sup> *See also: [Moddable Two Developer Guide](./documentation/devices/moddable-two.md), Moddable [product page](https://www.moddable.com/hardware)*<BR>
 <sup>[9]</sup> *See also: [Using the Moddable SDK with ESP32](./documentation/devices/esp32.md)*<BR>
 
 ### Pico by Raspberry Pi


### PR DESCRIPTION
Your web page re-design (great job by the way) broke some links so I fixed them.

In addition, `esp32.md` file contains a lot of dangling whitespace. I didn't really want to change it but I was not able to stop my editor and/or git from fixing it. My apologies.