### PR TITLE
Fix typings for SNTP

### DIFF
--- a/typings/sntp.d.ts
+++ b/typings/sntp.d.ts
@@ -32,7 +32,7 @@ declare module "sntp" {
   )
   type SNTPCallback = (message: SNTPCallbackMessage, value?: number) => void;
   class SNTP {
-    static readonly time: SNTPUnableToRetrieveTime;
+    static readonly time: SNTPTimeRetrieved;
     static readonly retry: SNTPRetry;
     static readonly error: SNTPUnableToRetrieveTime;
 


### PR DESCRIPTION
I found a small mistake of a callback message of SNTP typings. Here is the fix.