### PR TITLE
examples/piu/outline/figures works on ESP32 devices

### DIFF
--- a/examples/piu/outline/figures/CanvasPath/manifest.json
+++ b/examples/piu/outline/figures/CanvasPath/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"

--- a/examples/piu/outline/figures/FreeTypePath/manifest.json
+++ b/examples/piu/outline/figures/FreeTypePath/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"

--- a/examples/piu/outline/figures/PolygonPath/manifest.json
+++ b/examples/piu/outline/figures/PolygonPath/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"

--- a/examples/piu/outline/figures/RoundRectPath/manifest.json
+++ b/examples/piu/outline/figures/RoundRectPath/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"

--- a/examples/piu/outline/figures/SVGPath/manifest.json
+++ b/examples/piu/outline/figures/SVGPath/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"

--- a/examples/piu/outline/figures/linecaps/manifest.json
+++ b/examples/piu/outline/figures/linecaps/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"

--- a/examples/piu/outline/figures/linejoins/manifest.json
+++ b/examples/piu/outline/figures/linejoins/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"

--- a/examples/piu/outline/figures/rotate/manifest.json
+++ b/examples/piu/outline/figures/rotate/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"

--- a/examples/piu/outline/figures/rules/manifest.json
+++ b/examples/piu/outline/figures/rules/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"

--- a/examples/piu/outline/figures/scale/manifest.json
+++ b/examples/piu/outline/figures/scale/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"

--- a/examples/piu/outline/figures/translate/manifest.json
+++ b/examples/piu/outline/figures/translate/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": [
 			"./mod"


### PR DESCRIPTION
Some devices like `esp32/m5stack` needs to include `manifest_mod.json` to run mod.
This PR add include section to mods under `examples/piu/outline/figures`.