### PR TITLE
bit_num -> duty_resolution

### DIFF
--- a/modules/pins/servo/esp32/modServo.c
+++ b/modules/pins/servo/esp32/modServo.c
@@ -53,9 +53,9 @@ void xs_servo(xsMachine *the)
 	double d;
 	ledc_timer_config_t ledc_timer = {
 #if SOC_LEDC_TIMER_BIT_WIDE_NUM > 14
- 		.bit_num = LEDC_TIMER_15_BIT,
+ 		.duty_resolution = LEDC_TIMER_15_BIT,
 #else
-		.bit_num = LEDC_TIMER_14_BIT,
+		.duty_resolution = LEDC_TIMER_14_BIT,
 #endif
 		.freq_hz = 50,
 #if SOC_LEDC_SUPPORT_HS_MODE


### PR DESCRIPTION
Unfortunately, after the fix for https://github.com/Moddable-OpenSource/moddable/issues/1088, the changes were rolled back by another commit, leading to build failures with ESP-IDF v5.1.1. This is a quick fix for this issue.