### PR TITLE
use PICO_SDK_DIR instead of PICO_SDK_PATH

### DIFF
--- a/build/devices/pico/manifest.json
+++ b/build/devices/pico/manifest.json
@@ -12,7 +12,7 @@
 			"$(MODULES)/base/time/esp/*",
 			"$(MODULES)/base/timer/*",
 			"$(MODULES)/base/timer/mc/*",
-			"$(PICO_SDK_PATH)/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.pio"
+			"$(PICO_SDK_DIR)/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.pio"
 		]
 	},
 	"creation": {


### PR DESCRIPTION
When I build application with `pico`, I got a below error message. 

```
mcconfig -d -m -p pico/pico_lcd_1.3
### Error: '$(PICO_SDK_PATH)/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.pio': directory not found!
```
Accoriding to [setup guide](https://github.com/Moddable-OpenSource/moddable/blob/cdcab496ffa3108cbb4fe48bc284dd630984c9f6/documentation/devices/pico.md#getting-started-with-raspberry-pi-pico),  now we should use `PICO_SDK_DIR` instead of `PICO_SDK_PATH`.