### PR TITLE
Compartment.prototype.@@toStringTag property

### DIFF
--- a/tests/xs/built-ins/Compartment/prototype/Symbol.toStringTag-lockdown.js
+++ b/tests/xs/built-ins/Compartment/prototype/Symbol.toStringTag-lockdown.js
@@ -1,0 +1,13 @@
+/*---
+description:
+includes: [propertyHelper.js]
+features: [Symbol.toStringTag]
+---*/
+
+lockdown();
+
+assert.sameValue(Compartment.prototype[Symbol.toStringTag], 'Compartment');
+
+verifyNotEnumerable(Compartment.prototype, Symbol.toStringTag);
+verifyNotWritable(Compartment.prototype, Symbol.toStringTag);
+verifyNotConfigurable(Compartment.prototype, Symbol.toStringTag);

--- a/xs/tools/xst.c
+++ b/xs/tools/xst.c
@@ -350,6 +350,7 @@ int main(int argc, char* argv[])
 				xsSet(xsGlobal, xsID("gc"), xsResult);
 				xsResult = xsNewHostFunction(fx_fillBuffer, 2);
 				xsSet(xsGlobal, xsID("fillBuffer"), xsResult);
+#endif
 
 				xsResult = xsNewHostFunction(fx_harden, 1);
 				xsDefine(xsGlobal, xsID("harden"), xsResult, xsDontEnum);
@@ -359,7 +360,6 @@ int main(int argc, char* argv[])
 				xsDefine(xsGlobal, xsID("petrify"), xsResult, xsDontEnum);
 				xsResult = xsNewHostFunction(fx_mutabilities, 1);
 				xsDefine(xsGlobal, xsID("mutabilities"), xsResult, xsDontEnum);
-#endif
 
 				xsVar(0) = xsUndefined;
 				the->rejection = &xsVar(0);


### PR DESCRIPTION
I propose two changes.

1. Make `lockdown` available generally, but specifically so that test262 tests under `xst` can be framed for the language before and after `lockdown()`.
2. Adds a post-lockdown test for `Compartment.prototype.@@toStringTag` by way of demonstration
3. ~Consistent with my intuition, `Compartment.prototype.@@toStringTag` should be writable and configurable before `lockdown`. The pre-lockdown environment should be profanely mutable so that a shim can evolve the language, including the subsequent behavior of `lockdown`.~