### PR TITLE
Switch slot of I2S

### DIFF
--- a/build/devices/esp32/targets/m5stack_cores3/manifest.json
+++ b/build/devices/esp32/targets/m5stack_cores3/manifest.json
@@ -106,7 +106,7 @@
 			"volume_divider": 1,
 			"i2s": {
 				"num": 1,
-				"slot": 1,
+				"slot": "I2S_STD_SLOT_LEFT",
 				"bitsPerSample": 16,
 				"bck_pin": 34,
 				"lr_pin": 33,

--- a/build/devices/esp32/targets/m5stack_cores3/manifest.json
+++ b/build/devices/esp32/targets/m5stack_cores3/manifest.json
@@ -106,6 +106,7 @@
 			"volume_divider": 1,
 			"i2s": {
 				"num": 1,
+				"slot": 1,
 				"bitsPerSample": 16,
 				"bck_pin": 34,
 				"lr_pin": 33,

--- a/modules/pins/i2s/audioout.c
+++ b/modules/pins/i2s/audioout.c
@@ -79,7 +79,7 @@
 		#endif
 	#endif
 	#ifndef MODDEF_AUDIOOUT_I2S_SLOT
-		#define MODDEF_AUDIOOUT_I2S_SLOT 0
+ 		#define MODDEF_AUDIOOUT_I2S_SLOT I2S_STD_SLOT_RIGHT
 	#endif
 #endif
 
@@ -1512,11 +1512,7 @@ void audioOutLoop(void *pvParameter)
 	i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
 #else
 	i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_MONO;
-	#if MODDEF_AUDIOOUT_I2S_SLOT == 1
-		i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_LEFT;
-	#else
-		i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_RIGHT;
-	#endif
+	i2s_config.slot_cfg.slot_mask = MODDEF_AUDIOOUT_I2S_SLOT;;
 #endif
 	i2s_config.slot_cfg.ws_pol = false;
 	i2s_config.slot_cfg.bit_shift = false;

--- a/modules/pins/i2s/audioout.c
+++ b/modules/pins/i2s/audioout.c
@@ -78,6 +78,9 @@
 			#define MODDEF_AUDIOOUT_I2S_DAC_CHANNEL 3
 		#endif
 	#endif
+	#ifndef MODDEF_AUDIOOUT_I2S_SLOT
+		#define MODDEF_AUDIOOUT_I2S_SLOT 0
+	#endif
 #endif
 
 #if PICO_BUILD
@@ -1509,7 +1512,11 @@ void audioOutLoop(void *pvParameter)
 	i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
 #else
 	i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_MONO;
-	i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_RIGHT;
+	#if MODDEF_AUDIOOUT_I2S_SLOT == 1
+		i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_LEFT;
+	#else
+		i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_RIGHT;
+	#endif
 #endif
 	i2s_config.slot_cfg.ws_pol = false;
 	i2s_config.slot_cfg.bit_shift = false;


### PR DESCRIPTION
This PR is fix for #1236.

Setting I2S slot to left make M5Stack cores3 to AudioOut sound. 
This fix affects only `esp32/m5stack_cores3`.
