### PR TITLE
Add fuzzilli builds on Linux

### DIFF
--- a/xs/sources/xsMemory.c
+++ b/xs/sources/xsMemory.c
@@ -264,6 +264,12 @@ void* fxCheckChunk(txMachine* the, txChunk* chunk, txSize size, txSize offset)
 	return C_NULL;
 }
 
+#if defined(__clang__) || defined (__GNUC__)
+# define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#else
+# define ATTRIBUTE_NO_SANITIZE_ADDRESS
+#endif
+ATTRIBUTE_NO_SANITIZE_ADDRESS
 void fxCheckCStack(txMachine* the)
 {
     char x;

--- a/xs/sources/xsScript.c
+++ b/xs/sources/xsScript.c
@@ -37,6 +37,12 @@
 
 #include "xsScript.h"
 
+#if defined(__clang__) || defined (__GNUC__)
+# define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#else
+# define ATTRIBUTE_NO_SANITIZE_ADDRESS
+#endif
+ATTRIBUTE_NO_SANITIZE_ADDRESS
 void fxCheckParserStack(txParser* parser, txInteger line)
 {
     char x;

--- a/xs/tools/xst.c
+++ b/xs/tools/xst.c
@@ -1656,7 +1656,7 @@ void __sanitizer_cov_reset_edgeguards()
 	for (uint32_t *x = __edges_start; x < __edges_stop && N < MAX_EDGES; x++)
 		*x = ++N;
 }
-#ifndef __linux__
+
 void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop)
 {
 	// Avoid duplicate initialization
@@ -1708,7 +1708,7 @@ void __sanitizer_cov_trace_pc_guard(uint32_t *guard)
 	__shmem->edges[index / 8] |= 1 << (index % 8);
 	*guard = 0;
 }
-#endif
+
 
 #define REPRL_CRFD 100
 #define REPRL_CWFD 101


### PR DESCRIPTION
XS allows builds of xst that implement the Fuzzilli REPRL protocol for fuzzing by enabling the `FUZZING` and `FUZZILLI` flags. However, they were only available for Mac. This PR enables the corresponding Linux build, removing the requirement of a Mac machine for deeper engine fuzzing.

Aside from the fuzzilli coverage guards being disabled in Linux, the stack overflow check interferes with ASAN's `stack-use-after-free` due to promoting stack variables to the heap, which breaks the check's assumptions. This prevented fuzzilli on Linux from successfully starting and gaining coverage. To avoid this, we disable ASAN in these functions.

An alternative to disabling ASAN for this function could be using ASAN's interface to get the addr of the pointer on the stack, but I have not tested that yet. 