### PR TITLE
Add support for more sanitizers in fuzzilli builds

### DIFF
--- a/xs/makefiles/lin/xst.mk
+++ b/xs/makefiles/lin/xst.mk
@@ -41,8 +41,7 @@ SRC_DIR = $(XS_DIR)/sources
 TLS_DIR = $(XS_DIR)/tools
 TMP_DIR = $(BUILD_DIR)/tmp/lin/$(GOAL)/$(NAME)
 
-MACOS_ARCH ?= -arch i386
-MACOS_VERSION_MIN ?= -mmacosx-version-min=10.7
+ARCH := $(shell uname -m)
 LINK_OPTIONS = -rdynamic
 
 C_OPTIONS = \
@@ -91,8 +90,26 @@ ifeq ($(GOAL),debug)
 		endif
 	else
 		C_OPTIONS += -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter 
-		LINK_OPTIONS += -fsanitize=address -fno-omit-frame-pointer
-		C_OPTIONS += -fsanitize=address -fno-omit-frame-pointer
+		# use asan by default, unless another sanitizer is
+		# requested via sanitizer
+		ifeq ($(SANITIZER), memory)
+			C_OPTIONS += -fsanitize=memory -fsanitize-memory-track-origins
+			LINK_OPTIONS += -fsanitize=memory
+		else ifeq ($(SANITIZER), undefined)
+			C_OPTIONS += -fsanitize=bool,builtin,enum,float-divide-by-zero,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=bool,builtin,enum,float-divide-by-zero,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr -fsanitize-recover=undefined
+			LINK_OPTIONS += -fsanitize=bool,builtin,enum,float-divide-by-zero,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=bool,builtin,enum,float-divide-by-zero,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr -fsanitize-recover=undefined
+
+			# function and other ubsan checks not available in some arch, such as arm
+			ifneq ($(ARCH), aarch64)
+				C_OPTIONS += -fsanitize=array-bounds,function,unsigned-integer-overflow
+				LINK_OPTIONS += -fsanitize=array-bounds,function,unsigned-integer-overflow
+			endif
+		else
+			C_OPTIONS += -fsanitize=address
+			LINK_OPTIONS += -fsanitize=address
+		endif
+		C_OPTIONS += -fno-omit-frame-pointer
+		LINK_OPTIONS += -fno-omit-frame-pointer
 	endif
 
 	ifneq ($(FUZZILLI),0)

--- a/xs/makefiles/mac/xst.mk
+++ b/xs/makefiles/mac/xst.mk
@@ -91,8 +91,15 @@ ifneq ("x$(SDKROOT)", "x")
 endif
 
 ifeq ($(GOAL),debug)
-	C_OPTIONS += -DmxASANStackMargin=131072 -fsanitize=address -fno-omit-frame-pointer -fsanitize-blacklist=xst_no_asan.txt
-	LINK_OPTIONS += -fsanitize=address -fno-omit-frame-pointer
+	ifeq ($(SANITIZER), undefined)
+		C_OPTIONS += -fsanitize=bool,builtin,enum,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=bool,builtin,enum,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr,array-bounds,function
+		LINK_OPTIONS += -fsanitize=bool,builtin,enum,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr -fno-sanitize-recover=bool,builtin,enum,integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,shift,signed-integer-overflow,unreachable,vla-bound,vptr,array-bounds,function
+	else
+		C_OPTIONS += -fsanitize=address -fsanitize-blacklist=xst_no_asan.txt
+		LINK_OPTIONS += -fsanitize=address
+	endif
+	C_OPTIONS += -DmxASANStackMargin=131072 -fno-omit-frame-pointer
+	LINK_OPTIONS += -fno-omit-frame-pointer
 
 	ifneq ($(FUZZING),0)
 		C_OPTIONS += -DmxNoChunks=1

--- a/xs/sources/xsMemory.c
+++ b/xs/sources/xsMemory.c
@@ -264,6 +264,12 @@ void* fxCheckChunk(txMachine* the, txChunk* chunk, txSize size, txSize offset)
 	return C_NULL;
 }
 
+#if defined(__clang__) || defined (__GNUC__)
+# define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#else
+# define ATTRIBUTE_NO_SANITIZE_ADDRESS
+#endif
+ATTRIBUTE_NO_SANITIZE_ADDRESS
 void fxCheckCStack(txMachine* the)
 {
     char x;

--- a/xs/sources/xsScript.c
+++ b/xs/sources/xsScript.c
@@ -37,6 +37,12 @@
 
 #include "xsScript.h"
 
+#if defined(__clang__) || defined (__GNUC__)
+# define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#else
+# define ATTRIBUTE_NO_SANITIZE_ADDRESS
+#endif
+ATTRIBUTE_NO_SANITIZE_ADDRESS
 void fxCheckParserStack(txParser* parser, txInteger line)
 {
     char x;

--- a/xs/tools/xst.c
+++ b/xs/tools/xst.c
@@ -1725,10 +1725,15 @@ void fx_fuzzilli(xsMachine* the)
 				*((volatile char *)0) = 0;
 				break;
  			case 1: {
-				// check ASAN
-				char *data = malloc(64);
-				free(data);
-				data[0]++;
+				// check sanitizer
+				// this code is so buggy its bound to trip
+				// different sanitizers
+				size_t s = -1;
+				txSize txs = s + 1;
+				char buf[2];
+				char* bufptr = &buf;
+				bufptr[4] = (buf[0] == buf[1]) ? 0 : 1;
+				*((volatile char *)0) = 0;
 				} break;
  			case 2:
 				// check assert

--- a/xs/tools/xst.c
+++ b/xs/tools/xst.c
@@ -1656,7 +1656,7 @@ void __sanitizer_cov_reset_edgeguards()
 	for (uint32_t *x = __edges_start; x < __edges_stop && N < MAX_EDGES; x++)
 		*x = ++N;
 }
-#ifndef __linux__
+
 void __sanitizer_cov_trace_pc_guard_init(uint32_t *start, uint32_t *stop)
 {
 	// Avoid duplicate initialization
@@ -1708,7 +1708,7 @@ void __sanitizer_cov_trace_pc_guard(uint32_t *guard)
 	__shmem->edges[index / 8] |= 1 << (index % 8);
 	*guard = 0;
 }
-#endif
+
 
 #define REPRL_CRFD 100
 #define REPRL_CWFD 101


### PR DESCRIPTION
This PR builds on #1300 and adds additional sanitizers in debug builds:

* [UndefinedBehaviorSanitizer (UBSAN)](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html), which allows fuzzilli to find test cases that invoke undefined behavior. This can find issues that lead to the kind of memory violations that ASAN detects much earlier (e.g. optimized out bounds checking before it leads to an overflow).
* [MemorySanitizer (MSAN)](https://clang.llvm.org/docs/MemorySanitizer.html), which allows fuzzilli to find test cases that read uninitialized memory. Note that this sanitizer is only available in Linux.

These can be set via `SANITIZER=undefined` and `SANITIZER=memory` when building. The default for debug builds remains ASAN.

I have tested:

* These changes don't affect Mac builds (except for spurious stack overflow findings, which have occasionally shown up in Mac runs).
* UBSAN builds run on Mac by running for a couple weeks on an M1 Mac while I worked on the Linux port.
* UBSAN and MSAN builds run on Linux. They have run for weeks now and seem stable.