### PR TITLE
Add typings for Time#delta

### DIFF
--- a/typings/time.d.ts
+++ b/typings/time.d.ts
@@ -26,6 +26,7 @@ declare module "time" {
     timezone: number;
     dst: number;
     ticks: number;
+    delta(start: number, end?: number): number;
   }
   export {Time as default};
 }


### PR DESCRIPTION
This PR adds a type definition for `Time#delta` function added in https://github.com/Moddable-OpenSource/moddable/commit/d1e488fb1b1af95a873a260cd0073c9b5022cc0e