### PR TITLE
wavsteam for OpenAI text-to-speech

### DIFF
--- a/examples/pins/audioout/http-stream/manifest.json
+++ b/examples/pins/audioout/http-stream/manifest.json
@@ -1,9 +1,8 @@
 {
 	"include": [
 		"$(MODDABLE)/examples/manifest_base.json",
-		"$(MODDABLE)/modules/io/manifest.json",
-		"$(MODDABLE)/examples/io/tcp/httpclient/manifest_httpclient.json",
-		"$(MODDABLE)/modules/data/wavreader//manifest.json"
+		"./manifest_sbcstreamer.json",
+		"./manifest_wavstreamer.json"
 	],
 	"creation": {
 		"static": 32768,
@@ -19,18 +18,12 @@
 	"modules": {
 		"*": [
 			"./main",
-			"./sbcstreamer",
-			"./wavstreamer",
 			"./calculatePower"
 		],
 		"pins/*": [
 			"$(MODULES)/pins/i2s/*"
 		]
 	},
-	"preload": [
-		"sbcstreamer",
-		"wavstreamer"
-	],
 	"defines": {
 		"audioOut": {
 			"bitsPerSample": 16,

--- a/examples/pins/audioout/http-stream/manifest_sbcstreamer.json
+++ b/examples/pins/audioout/http-stream/manifest_sbcstreamer.json
@@ -1,0 +1,10 @@
+{
+  "include": [
+    "$(MODDABLE)/modules/io/manifest.json",
+    "$(MODDABLE)/examples/io/tcp/httpclient/manifest_httpclient.json"
+  ],
+  "modules": {
+    "*": ["./sbcstreamer"]
+  },
+  "preload": ["sbcstreamer"]
+}

--- a/examples/pins/audioout/http-stream/manifest_wavstreamer.json
+++ b/examples/pins/audioout/http-stream/manifest_wavstreamer.json
@@ -1,0 +1,11 @@
+{
+  "include": [
+    "$(MODDABLE)/modules/io/manifest.json",
+    "$(MODDABLE)/examples/io/tcp/httpclient/manifest_httpclient.json",
+    "$(MODDABLE)/modules/data/wavreader/manifest.json"
+  ],
+  "modules": {
+    "*": ["./wavstreamer"]
+  },
+  "preload": ["wavstreamer"]
+}

--- a/examples/pins/audioout/openai-stream/main.js
+++ b/examples/pins/audioout/openai-stream/main.js
@@ -36,6 +36,6 @@ new OpenAIStreamer({
 	},
 	onDone() {
 		trace("OpenAI Done\n");
-		this.close();
+		this.close?.();
 	}
 })

--- a/examples/pins/audioout/openai-stream/manifest_openaistreamer.json
+++ b/examples/pins/audioout/openai-stream/manifest_openaistreamer.json
@@ -1,7 +1,8 @@
 {
 	"include": [
 		"$(MODDABLE)/examples/io/tcp/httpsclient/manifest_httpsclient.json",
-		"../mp3-http-stream/manifest_mp3streamer.json"
+		"../mp3-http-stream/manifest_mp3streamer.json",
+		"../http-stream/manifest_wavstreamer.json"
 	],
 	"modules": {
 		"*": "./openaistreamer"
@@ -9,7 +10,7 @@
 	"preload": "openaistreamer",
 	"data": { 
 		"*": [
-			"$(MODULES)/crypt/data/ca35"
+			"$(MODULES)/crypt/data/ca233"
 		]
 	}
 }

--- a/examples/pins/audioout/openai-stream/openaistreamer.js
+++ b/examples/pins/audioout/openai-stream/openaistreamer.js
@@ -26,27 +26,21 @@ import WavStreamer from "wavstreamer";
 export default class {
 	constructor(options) {
 		const {key, model, voice, input, speed, response_format, ...o} = options;
-		const reuest = {
+		const request = {
 			input,
 			model,
 			voice,
 			speed: speed ?? 1,
 			response_format: response_format ?? "mp3",
 		};
-		const body = ArrayBuffer.fromString(JSON.stringify(reuest));
+		const body = ArrayBuffer.fromString(JSON.stringify(request));
 		let streamer;
-		if (reuest.response_format == "mp3") {
+		if (request.response_format == "mp3") {
 			streamer = MP3Streamer;
-		} else if (reuest.response_format == "wav") {
+		} else if (request.response_format == "wav") {
 			streamer = WavStreamer;
 		} else {
-			const error = new Error(`invalid response_format:${reuest.response_format}`);
-			if (options.onError) {
-				options.onError(error);
-				return;
-			} else {
-				throw error;
-			}
+			throw new Error(`invalid response_format:${request.response_format}`);
 		}
 	
 		return new streamer({
@@ -68,7 +62,7 @@ export default class {
 			port: 443,
 			host: "api.openai.com",
 			path: "/v1/audio/speech",
-			waveHeaderBytes: reuest.response_format == "wav" ? 44 : undefined,
+			waveHeaderBytes: request.response_format == "wav" ? 44 : undefined,
 		})
 	}
 }


### PR DESCRIPTION
This PR addd parameter `response_format` to [OpenAI text-to-speech.](https://platform.openai.com/docs/api-reference/audio/createSpeech)
Depending on the situation, I think there are cases where `wav` might be better than `mp3`.

Furthermore, this PR includes change for the following points.

* split `manifest.json` of  `http-steam` into `manifest_sbcstreamer.json` and `manifest_wavstremer.json`
* TLS Certification for OpenAI API.







