### PR TITLE
fix: don't crash when snapshotting a host object that has a (valid) destructor

### DIFF
--- a/xs/sources/xsSnapshot.c
+++ b/xs/sources/xsSnapshot.c
@@ -1092,10 +1092,7 @@ void fxMeasureSlot(txMachine* the, txSnapshot* snapshot, txSlot* slot, txSize* c
 				destructor = slot->value.host.variant.hooks->destructor;
 			else
 				destructor = slot->value.host.variant.destructor;
-		    if (dladdr(destructor, &info)) {
-				mxAssert(0, "# snapshot: no host destructor: %s!\n", info.dli_sname);
-			}
-			else {
+		    if (dladdr(destructor, &info) == 0) {
 				mxAssert(0, "# snapshot: no host destructor!\n");
 			}
 		}


### PR DESCRIPTION
If you create a host object using `xsNewHostObject` and provide it with a (valid) destructor, attempting to perform a snapshot causes a crash.   I think this was a simple oversight, but in any case this is a proposed fix.