### PR TITLE
No ASAN on regex stack check

### DIFF
--- a/xs/sources/xsre.c
+++ b/xs/sources/xsre.c
@@ -2033,7 +2033,9 @@ void fxWordContinueCode(txPatternParser* parser, void* it, txInteger direction, 
 	*buffer++ = sequel;
 }
 
-
+#if defined(__clang__) || defined (__GNUC__)
+	__attribute__((no_sanitize_address))
+#endif
 void fxPatternParserCheckStack(txPatternParser* parser)
 {
     char x;


### PR DESCRIPTION
XS checks by stack overflow by checking if new stack variables have a lower address than the one returned by `fxCStackLimit`, stored in the VM's `stackLimit` or in this case the parser structure's `stackLimit`. However, ASAN can change the memory layout in ways that break this check (see #1300 for more context). We disable ASAN in this function, to prevent instrumentation from interfering with stack overflow detection.