### PR TITLE
Add support for M5Stack Core2 v1.1

### DIFF
--- a/build/devices/esp32/targets/m5stack_core2/manifest.json
+++ b/build/devices/esp32/targets/m5stack_core2/manifest.json
@@ -8,7 +8,8 @@
 	"include": [
 		"$(MODDABLE)/modules/drivers/ili9341/manifest.json",
 		"$(MODDABLE)/modules/drivers/ft6206/manifest.json",
-		"$(MODDABLE)/modules/drivers/axp192/manifest.json"
+		"$(MODDABLE)/modules/drivers/axp192/manifest.json",
+		"$(MODDABLE)/modules/drivers/axp2101/manifest.json"
 	],
 	"config": {
 		"screen": "ili9341",

--- a/build/devices/esp32/targets/m5stack_core2/setup-target.js
+++ b/build/devices/esp32/targets/m5stack_core2/setup-target.js
@@ -292,7 +292,6 @@ class PowerAXP2101 extends AXP2101 {
 
     // main power line
     this._dcdc1.voltage = 3350;
-    //this.chargeEnable = true; // これがあるとなぜか動かない
 
     // LCD
     this.lcd = this._bldo1;

--- a/build/devices/esp32/targets/m5stack_core2/setup-target.js
+++ b/build/devices/esp32/targets/m5stack_core2/setup-target.js
@@ -72,10 +72,12 @@ export default function (done) {
 	};
 
 	// power
-  const powerICID = new SMBus({
+  const s = new SMBus({
     ...INTERNAL_I2C,
     address: 0x34,
-  }).readByte(0x03)
+  })
+  const powerICID = s.readByte(0x03)
+  s.close();
 
 	globalThis.power =
     powerICID === 0x03 ? new PowerAXP192() : new PowerAXP2101() /* expects 0x4a */;

--- a/build/devices/esp32/targets/m5stack_core2/setup-target.js
+++ b/build/devices/esp32/targets/m5stack_core2/setup-target.js
@@ -72,7 +72,6 @@ export default function (done) {
 	};
 
 	// power
-  debugger;
   const powerICID = new SMBus({
     ...INTERNAL_I2C,
     address: 0x34,

--- a/modules/drivers/axp2101/axp2101.js
+++ b/modules/drivers/axp2101/axp2101.js
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2019 Shinya Ishikawa, 2024 RChikamura
+ *   Copyright (c) 2019-2024 Shinya Ishikawa, 2024 RChikamura
  *
  *   This file is part of the Moddable SDK Runtime.
  *
@@ -19,148 +19,95 @@
  */
 import SMBus from "pins/smbus";
 
+function vToByte(v, steps, points) {
+  if (v < points[0]) {
+    return 0;
+  }
+  let base = 0;
+  for (let i = 1; i < points.length; i++) {
+    const step = steps[i - 1];
+    if (v < points[i]) {
+      return base + (v - points[i - 1]) * step;
+    }
+    base += (points[i] - points[i - 1]) * step;
+  }
+  return base;
+}
+
+function byteToV(byte, points, steps) {
+  if (byte <= 0) {
+    return points[0]
+  }
+  let base = 0;
+  for (let i = 1; i < points.length; i++) {
+    const step = steps[i - 1];
+    const delta = (points[i] - points[i - 1]) * step;
+    if (byte <= base + delta) {
+      return points[i - 1] + (byte - base) / step;
+    }
+    base += delta;
+  }
+  // should not be here since the byte value is over the maximum
+  return points[points.length - 1] + (byte - base) / steps[steps.length - 1];
+
+}
 class DCDC {
   #parent;
-  #register;
-  constructor({ register, parent }) {
+  #registerV;
+  #mask;
+  #points;
+  #steps;
+
+  constructor({ registerV, parent, mask, points, steps }) {
     this.#parent = parent;
-    this.#register = register;
+    this.#registerV = registerV;
+    this.#mask = mask;
+    this.#points = points;
+    this.#steps = steps;
   }
+
   set voltage(v) {
-    let vtemp; // 電圧>設定値の計算結果を代入する変数
-    let mask = 0x80; // 電圧設定値をレジスタに書き込む際に使用。電圧設定のビットを0とし、それ以外を１とする。
-    switch (
-      this.#register // AXP2101にはDCDC1~5までがあるらしい(少なくとも4までは回路図にある)が、全部設定が違うので分岐
-    ) {
-      case 0x82: // DCDC1
-        vtemp = v < 1500 ? 0 : v < 3400 ? (v - 1500) / 100 : 19;
-        mask = 0xe0; // 下位5bitが電圧設定
-        break;
-      case 0x83: // DCDC2
-        vtemp =
-          v < 500
-            ? 0
-            : v <= 1200
-            ? (v - 500) / 10
-            : v <= 1540
-            ? (v - 1200) / 20 + 70
-            : 87;
-        break;
-      case 0x84: // DCDC3
-        vtemp =
-          v < 500
-            ? 0
-            : v <= 1200
-            ? (v - 500) / 10
-            : v <= 1540
-            ? (v - 1200) / 20 + 70
-            : v < 1600
-            ? 87
-            : v <= 3400
-            ? (v - 1600) / 20 + 88
-            : 107;
-        break;
-      case 0x85: // DCDC4
-        vtemp =
-          v < 500
-            ? 0
-            : v <= 1200
-            ? (v - 500) / 10
-            : v <= 1840
-            ? (v - 1200) / 20 + 70
-            : 102;
-        break;
-      case 0x86: // DCDC5
-        vtemp = v < 1400 ? 0 : v < 3700 ? (v - 1400) / 100 : 23;
-        mask = 0xe0; // 下位5bitが電圧設定
-        break;
-      default: // どれでもなければとりあえず0, maskもとりあえず標準(下位7bit)
-        vtemp = 0;
-        break;
-    }
-    const vdata = vtemp;
+    const byte = vToByte(v, this.#points, this.#steps);
     this.#parent.writeByte(
-      this.#register,
-      (this.#parent.readByte(this.#register) & mask) | (vdata & ~mask)
+      this.#registerV,
+      (this.#parent.readByte(this.#registerV) & this.#mask) |
+      (byte & ~this.#mask)
     );
   }
   get voltage() {
-    let v = 0;
-    let vdata = this.#parent.readByte(this.#register);
-
-    switch (
-      this.#register // AXP2101にはDCDC1~5までがあるらしい(少なくとも4までは回路図にある)が、全部設定が違うので分岐
-    ) {
-      case 0x82: // DCDC1
-        vdata &= 0x1f;
-        v = vdata * 100 + 1500;
-        break;
-      case 0x83: // DCDC2
-      case 0x85: // DCDC4 DCDC2とは上限値違いなだけのため、共通化
-        vdata &= 0x7f;
-        v = vdata <= 70 ? vdata * 10 + 500 : (vdata - 70) * 20 + 1200;
-        break;
-      case 0x84: // DCDC3
-        vdata &= 0x7f;
-        v =
-          vdata <= 70
-            ? vdata * 10 + 500
-            : vdata <= 87
-            ? (vdata - 70) * 20 + 1200
-            : (vdata - 88) * 100 + 1600;
-        break;
-      case 0x86: // DCDC5
-        vdata &= 0x1f;
-        v = vdata * 100 + 1400;
-        break;
-      default: // どれでもなければ何もしない(値は0になる)
-        break;
-    }
-
-    return v;
+    let byte = this.#parent.readByte(this.#registerV);
+    return byteToV(byte & this.#mask, this.#points, this.#steps)
   }
 }
 
 class LDO {
   #parent;
-  #register;
-  #registerEn; // 追加 ただし、dldo2だけ0x91, それ以外は0x90なので、registerの値から条件演算子で選択する方式にする
+  #registerV;
+  #registerEn;
   #offsetEn;
+  #points;
+  #steps;
   // offsetVを削除し、#registerEnの自動判別コードを追加
-  constructor({ register, parent, offsetEn }) {
+  constructor({ registerV, registerEn, parent, offsetEn, points, steps }) {
     this.#parent = parent;
-    this.#register = register;
-    this.#registerEn = register == 0x9a ? 0x91 : 0x90;
+    this.#registerV = registerV;
+    this.#registerEn = registerEn;
     this.#offsetEn = offsetEn;
+    this.#points = points;
+    this.#steps = steps;
   }
-  set voltage(v) {
 
-    const vdata =
-      this.#register == 0x98 || this.#register == 0x9a
-        ? v < 500
-          ? 0
-          : v > 1400
-            ? 19
-            : (v - 500) / 50
-        : v < 500
-          ? 0
-          : v > 3500
-            ? 30
-            : (v - 500) / 100;
+  set voltage(v) {
+    const byte = vToByte(v, this.#points, this.#steps)
     this.#parent.writeByte(
-      this.#register,
-      (this.#parent.readByte(this.#register) & 0x1f) | vdata
-    ); //下位5bitに電圧設定を書き込み
+      this.#registerV,
+      (this.#parent.readByte(this.#registerV) & 0x1f) | byte
+    );
   }
 
   get voltage() {
-    let vdata = this.#parent.readByte(this.#register) & 0x1f;
-    let v =
-      this.#register == 0x98 || this.#register == 0x9a
-        ? vdata * 50 + 500
-        : vdata * 100 + 500;
-
-    return v;
+    const byte = this.#parent.readByte(this.#registerV) & 0x1f;
+    return byteToV(byte);
   }
 
   set enable(enable) {
@@ -189,17 +136,94 @@ export default class AXP2101 extends SMBus {
   constructor(it) {
     super({ address: 0x34, ...it });
 
-    //データシートとaxp192.jsのコードを参考に追加
-    this._dcdc1 = new DCDC({ register: 0x82, parent: this });
-    this._dcdc2 = new DCDC({ register: 0x83, parent: this });
-    this._dcdc3 = new DCDC({ register: 0x84, parent: this });
-    this._aldo1 = new LDO({ register: 0x92, parent: this, offsetEn: 0 });
-    this._aldo2 = new LDO({ register: 0x93, parent: this, offsetEn: 1 });
-    this._aldo3 = new LDO({ register: 0x94, parent: this, offsetEn: 2 });
-    this._aldo4 = new LDO({ register: 0x95, parent: this, offsetEn: 3 });
-    this._bldo1 = new LDO({ register: 0x96, parent: this, offsetEn: 4 });
-    this._bldo2 = new LDO({ register: 0x97, parent: this, offsetEn: 5 });
-    this._dldo1 = new LDO({ register: 0x99, parent: this, offsetEn: 7 });
+    this._dcdc1 = new DCDC({
+      registerV: 0x82,
+      parent: this,
+      points: [1500, 3400],
+      steps: [1 / 100],
+      mask: 0xe0,
+    });
+    this._dcdc2 = new DCDC({
+      registerV: 0x83,
+      parent: this,
+      points: [500, 1200, 1600],
+      steps: [1 / 10, 1 / 20],
+      mask: 0x80,
+    });
+    this._dcdc3 = new DCDC({
+      registerV: 0x84,
+      parent: this,
+      points: [500, 1200, 1540, 1600, 3400],
+      steps: [1 / 10, 1 / 20, 0, 1 / 20],
+      mask: 0x80,
+    });
+    this._dcdc4 = new DCDC({
+      registerV: 0x85,
+      parent: this,
+      points: [500, 1200, 1840],
+      steps: [1 / 10, 1 / 20],
+      mask: 0x80,
+    });
+    this._dcdc5 = new DCDC({
+      registerV: 0x86,
+      parent: this,
+      points: [1400, 3700],
+      steps: [1 / 100],
+      mask: 0xe0,
+    });
+
+    const PARAM_A = {
+      parent: this,
+      points: [500, 1400],
+      steps: [1 / 50],
+    };
+    const PARAM_B = {
+      parent: this,
+      points: [500, 3500],
+      steps: [1 / 100],
+    };
+    this._aldo1 = new LDO({
+      ...PARAM_B,
+      registerV: 0x92,
+      registerEn: 0x90,
+      offsetEn: 0,
+    });
+    this._aldo2 = new LDO({
+      ...PARAM_B,
+      registerV: 0x93,
+      registerEn: 0x90,
+      offsetEn: 1,
+    });
+    this._aldo3 = new LDO({
+      ...PARAM_B,
+      registerV: 0x94,
+      registerEn: 0x90,
+      offsetEn: 2,
+    });
+    this._aldo4 = new LDO({
+      ...PARAM_B,
+      registerV: 0x95,
+      registerEn: 0x90,
+      offsetEn: 3,
+    });
+    this._bldo1 = new LDO({
+      ...PARAM_B,
+      registerV: 0x96,
+      registerEn: 0x90,
+      offsetEn: 4,
+    });
+    this._bldo2 = new LDO({
+      ...PARAM_B,
+      registerV: 0x97,
+      registerEn: 0x90,
+      offsetEn: 5,
+    });
+    this._dldo1 = new LDO({
+      ...PARAM_B,
+      registerV: 0x99,
+      registerEn: 0x90,
+      offsetEn: 7,
+    });
   }
 
   isACINExist() {
@@ -246,7 +270,7 @@ export default class AXP2101 extends SMBus {
     this.writeByte(0x10, this.readByte(0x10) | 0b00000010); // POWERON Negative Edge IRQ(ponne_irq_en) enable
     this.writeByte(0x25, 0b00011011); // sleep and wait for wakeup
     Timer.delay(100);
-    this.writeByte(0x10, 0b00110001);  // power off
+    this.writeByte(0x10, 0b00110001); // power off
   }
 
   setChargeEnable(_enable) {
@@ -282,6 +306,7 @@ export default class AXP2101 extends SMBus {
 
   getBatteryVoltage() {
     const ADCLSB = 1.1 / 1000.0;
+    // TODO: implement
   }
 
   getBatteryLevel() {
@@ -293,37 +318,37 @@ export default class AXP2101 extends SMBus {
   getBatteryPower() {
     const VOLTAGE_LSB = 1.1;
     const CURRENT_LCS = 0.5;
-    return (VOLTAGE_LSB * CURRENT_LCS * this._read24Bit(0x70)) / 1000.0;
+    return (VOLTAGE_LSB * CURRENT_LCS * this.#read24Bit(0x70)) / 1000.0;
   }
 
   getVBUSVoltage() {
     const ADC_LSB = 1.7 / 1000.0;
-    return ADC_LSB * this._read12Bit(0x5a);
+    return ADC_LSB * this.#read12Bit(0x5a);
   }
 
   getVBUSCurrent() {
     const ADC_LSB = 0.375;
-    return ADC_LSB * this._read12Bit(0x5c);
+    return ADC_LSB * this.#read12Bit(0x5c);
   }
 
   getAXP173Temperature() {
     const ADC_LSB = 0.1;
     const OFFSET_DEG_C = -144.7;
-    return ADC_LSB * this._read12Bit(0x5e) + OFFSET_DEG_C;
+    return ADC_LSB * this.#read12Bit(0x5e) + OFFSET_DEG_C;
   }
 
   getTSTemperature() {
     const ADC_LSB = 0.1;
     const OFFSET_DEG_C = -144.7;
-    return ADC_LSB * this._read12Bit(0x62) + OFFSET_DEG_C;
+    return ADC_LSB * this.#read12Bit(0x62) + OFFSET_DEG_C;
   }
 
-  _read24Bit(address) {
+  #read24Bit(address) {
     const buff = this.readBlock(address, 3);
     return (buff[0] << 16) + (buff[1] << 8) + buff[2];
   }
 
-  _read12Bit(address) {
+  #read12Bit(address) {
     const buff = this.readBlock(address, 2);
     return (buff[0] << 4) + buff[1];
   }

--- a/modules/drivers/axp2101/axp2101.js
+++ b/modules/drivers/axp2101/axp2101.js
@@ -87,7 +87,6 @@ class LDO {
   #offsetEn;
   #points;
   #steps;
-  // offsetVを削除し、#registerEnの自動判別コードを追加
   constructor({ registerV, registerEn, parent, offsetEn, points, steps }) {
     this.#parent = parent;
     this.#registerV = registerV;


### PR DESCRIPTION
This is a pull request to support the minor update version v1.1 of the M5Stack Core2.
In v1.1, the power management IC has been changed from AXP192 to AXP2101 (which is also used in M5Stack CoreS3).

- In the setup-target.js of m5stack_core2, the power management IC's id is read and automatically identified. This maintains compatibility with previous versions of the M5Stack Core2.
 - Added some functions that are present in AXP192 but not in AXP2101.
- Some methods, such as setChargeEnable, reported by another user as not functioning, have been temporarily set to a not implemented status. We consider this to be of low urgency and would like to address it in a separate PR.

This change has been tested by writing the piu/balls demo to M5Stack v1.0, v1.1, and M5Stack CoreS3, and confirming its operation.

This PR was created with the cooperation of a new contributor, @RChikamura . He has been instructed to submit a CLA.