### PR TITLE
Add WiFi event definition  "station_connect" and "station_disconnect"

### DIFF
--- a/modules/network/wifi/esp32/wifi.js
+++ b/modules/network/wifi/esp32/wifi.js
@@ -54,4 +54,6 @@ export default class WiFi @ "xs_wifi_destructor" {
 	static lostIP = "lostIP";
 	static connected = "connect";
 	static disconnected = "disconnect";
+	static station_connect = "station_connect";
+	static station_disconnect = "station_disconnect";
 }

--- a/modules/network/wifi/wifi.js
+++ b/modules/network/wifi/wifi.js
@@ -54,6 +54,4 @@ export default class WiFi @ "xs_wifi_destructor" {
 	static lostIP = "lostIP";
 	static connected = "connect";
 	static disconnected = "disconnect";
-	static station_connect = "station_connect"
-	static station_disconnect = "station_disconnect"
 }

--- a/modules/network/wifi/wifi.js
+++ b/modules/network/wifi/wifi.js
@@ -54,4 +54,6 @@ export default class WiFi @ "xs_wifi_destructor" {
 	static lostIP = "lostIP";
 	static connected = "connect";
 	static disconnected = "disconnect";
+	static station_connect = "station_connect"
+	static station_disconnect = "station_disconnect"
 }

--- a/typings/wifi.d.ts
+++ b/typings/wifi.d.ts
@@ -24,7 +24,7 @@ declare module "wifi" {
     ssid: string,
     password?: string
   }
-  export type WiFiCallback = (message: "connect" | "gotIP" | "lostIP" | "disconnect") => void
+  export type WiFiCallback = (message: "connect" | "gotIP" | "lostIP" | "disconnect" | "station_connect" | "station_disconnect") => void
   export type WiFiScanCallback = (item: {
     ssid: string,
     authentication: string,
@@ -48,8 +48,10 @@ declare module "wifi" {
     static readonly lostIP: "lostIP";
     static readonly connected: "connect";
     static readonly disconnected: "disconnect";
-    
-    constructor(options: WiFiOptions, callback?: WiFiCallback);
+    static readonly station_connected: "station_connect";
+    static readonly station_disconnected: "station_disconnect";
+
+    constructor(options?: WiFiOptions, callback?: WiFiCallback);
     close(): void;
     static scan(options: ScanOptions, callback: WiFiScanCallback): void;
     static mode: StationMode | AccessPointMode;


### PR DESCRIPTION
In discussion https://github.com/Moddable-OpenSource/moddable/discussions/1342, I use motitoring msg `station_connect` and `station_disconnect` to detect connected devices in Wifi AP mode.

This PR add these definitions to `Wifi` class.