### PR TITLE
add typing qrcode

### DIFF
--- a/modules/commodetto/qrcode/pocoqrcode.js
+++ b/modules/commodetto/qrcode/pocoqrcode.js
@@ -20,5 +20,5 @@
 
 import Poco from "commodetto/PocoCore";
 
-Poco.prototype.drawQRCode = function (bits, x, y, scale, fore, back) @ "xs_poco_drawQRCode";
+Poco.prototype.drawQRCode = function (bits, x, y, scale, fore) @ "xs_poco_drawQRCode";
 

--- a/typings/commodetto/Poco.d.ts
+++ b/typings/commodetto/Poco.d.ts
@@ -79,6 +79,8 @@ declare module "commodetto/Poco" {
     bitmapRemove(bits: Bitmap): void
     compact(): void
 
+    drawQRCode(qrcode:ArrayBuffer, x: number, y: number, scale: number, fore: number)
+
     readonly width: number
     readonly height: number
     readonly pixelsOut: PixelsOut

--- a/typings/qrcode.d.ts
+++ b/typings/qrcode.d.ts
@@ -1,0 +1,32 @@
+/*
+* Copyright (c) 2024 Satoshi Tanaka
+*
+*   This file is part of the Moddable SDK Tools.
+*
+*   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   The Moddable SDK Tools is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+declare module "qrcode" {
+    interface qrcode extends ArrayBuffer {
+        size: number;
+    }
+
+    var qrCode: (options: {
+        input: string | BufferLike,
+        maxVersion?: number
+    }) => qrcode;
+
+    export { qrCode as default };
+}


### PR DESCRIPTION
This PR add typings for `modules/data/qrcode` and `drawQRCode`.
And I found that there was an unnecessary parameter `back` in `drawQRCode`, so I corrected it.