### PR TITLE
XS snapshot gxCallbacks for mxUint8ArrayBase64

### DIFF
--- a/xs/sources/xsSnapshot.c
+++ b/xs/sources/xsSnapshot.c
@@ -629,7 +629,15 @@ static txCallback gxCallbacks[mxCallbacksLength] = {
 	fx_Promise_withResolvers,
 	fx_RegExp_prototype_get_unicodeSets,
 	fx_String_prototype_isWellFormed,
-	fx_String_prototype_toWellFormed
+	fx_String_prototype_toWellFormed,
+#endif
+#if mxUint8ArrayBase64
+	fx_Uint8Array_fromBase64,
+	fx_Uint8Array_fromHex,
+	fx_Uint8Array_prototype_setFromBase64,
+	fx_Uint8Array_prototype_setFromHex,
+	fx_Uint8Array_prototype_toBase64,
+	fx_Uint8Array_prototype_toHex
 #endif
 };
 extern const txTypeDispatch gxTypeDispatches[];


### PR DESCRIPTION
This PR adds the respective `gxCallbacks` for mxUint8ArrayBase64 which is enabled by default as of https://github.com/Moddable-OpenSource/moddable/commit/14df95dc593cac217e9d49e7f85d25bc81d99349 and https://github.com/Moddable-OpenSource/moddable/commit/0635e9b3405f687782ae10c1cac12e6c521156b1.