### PR TITLE
Conditional signatures fxNewHostConstructor, fxNewHostFunction and fxNewHostInstance with -DINCLUDE_XSPLATFORM

### DIFF
--- a/xs/includes/xs.h
+++ b/xs/includes/xs.h
@@ -1439,9 +1439,15 @@ mxImport void fxArrayCacheEnd(xsMachine*, xsSlot*);
 mxImport void fxArrayCacheItem(xsMachine*, xsSlot*, xsSlot*);
 
 mxImport void fxBuildHosts(xsMachine*, xsIntegerValue, xsHostBuilder*);
+#ifndef INCLUDE_XSPLATFORM
 mxImport void fxNewHostConstructor(xsMachine*, xsCallback, xsIntegerValue, xsIntegerValue);
 mxImport void fxNewHostFunction(xsMachine*, xsCallback, xsIntegerValue, xsIntegerValue, xsIntegerValue);
 mxImport void fxNewHostInstance(xsMachine*);
+#else
+mxImport xsSlot* fxNewHostConstructor(xsMachine*, xsCallback, xsIntegerValue, xsIntegerValue);
+mxImport xsSlot* fxNewHostFunction(xsMachine*, xsCallback, xsIntegerValue, xsIntegerValue, xsIntegerValue);
+mxImport xsSlot* fxNewHostInstance(xsMachine*);
+#endif
 mxImport xsSlot* fxNewHostObject(xsMachine*, xsDestructor);
 mxImport xsIntegerValue fxGetHostBufferLength(xsMachine*, xsSlot*);
 mxImport void* fxGetHostChunk(xsMachine*, xsSlot*);


### PR DESCRIPTION
This PR adds conditional signatures with `-DINCLUDE_XSPLATFORM` to return `xsSlot*` instead of `void` for `fxNewHostConstructor`, `fxNewHostFunction` and `fxNewHostInstance`.

The current signatures result in conflicts when building xsnap with Emscripten, which are mitigated by the proposed changes. See [@SMotaal/xs-wasm](https://github.com/SMotaal/xs-wasm/tree/main?tab=readme-ov-file#patching) for more.

I am not sure if the proposed changes align with other build paths, and would appreciate your input to avoid breaking existing projects.