### PR TITLE
onerror callback of eventsource  sets http status code

### DIFF
--- a/examples/io/tcp/eventsource/eventsource.js
+++ b/examples/io/tcp/eventsource/eventsource.js
@@ -24,6 +24,51 @@ import Timer from "timer";
 import Headers from "headers";
 import URL from "url";
 
+const statusTexts = {
+	100: "Continue",
+	101: "Switching Protocols",
+	200: "OK",
+	201: "Created",
+	202: "Accepted",
+	203: "Non-Authoritative Information",
+	204: "No Content",
+	205: "Reset Content",
+	206: "Partial Content",
+	300: "Multiple Choices",
+	301: "Moved Permanently",
+	302: "Found",
+	303: "See Other",
+	304: "Not Modified",
+	305: "Use Proxy",
+	307: "Temporary Redirect",
+	400: "Bad Request",
+	401: "Unauthorized",
+	402: "Payment Required",
+	403: "Forbidden",
+	404: "Not Found",
+	405: "Method Not Allowed",
+	406: "Not Acceptable",
+	407: "Proxy Authentication Required",
+	408: "Request Timeout",
+	409: "Conflict",
+	410: "Gone",
+	411: "Length Required",
+	412: "Precondition Failed",
+	413: "Payload Too Large",
+	414: "URI Too Long",
+	415: "Unsupported Media Type",
+	416: "Range Not Satisfiable",
+	417: "Expectation Failed",
+	426: "Upgrade Required",
+	500: "Internal Server Error",
+	501: "Not Implemented",
+	502: "Bad Gateway",
+	503: "Service Unavailable",
+	504: "Gateway Timeout",
+	505: "HTTP Version Not Supported",
+};
+Object.freeze(statusTexts);
+
 const CR = -1;
 const BODY = 0;
 const COMMENT = 1;
@@ -181,7 +226,7 @@ class EventSource {
 				}
 				else {
 					client.close();
-					this.#onError();
+					this.#onError({status: status, statusText:statusTexts[status]});
 				}
 			},
 			onWritable(count) {
@@ -288,10 +333,10 @@ class EventSource {
 			this.#callEventListeners(event);
 		}
 	}
-	#onError() {
+	#onError(error) {
 		this.#client = null;
 		this.#readystate = this.CLOSED;
-		const event = { type:"error" };
+		const event = { type:"error", ...error };
 		this.#callEventListeners(event);
 	}
 	#processField(name, value) {


### PR DESCRIPTION
I am implementing the [streaming response of the ChatGPT API](https://platform.openai.com/docs/api-reference/streaming) using EventSource, but with the current EventSource, I cannot check the reason for the error response from the API. 

Therefore, in this Pull Request, I will set the `status` and `statusText` in the `onerror` callback when there is an error response from the API with a status other than 200.