### PR TITLE
mcconfig/mcmanifest escaping of '#' on Windows

### DIFF
--- a/tools/mcconfig.js
+++ b/tools/mcconfig.js
@@ -90,7 +90,7 @@ class MakeFile extends MAKEFILE {
 		for (var result of [].concat(tool.jsFiles, tool.tsFiles)) {
 			this.write("\\\n\t$(MODULES_DIR)");
 			this.write(tool.slash);
-			this.write(result.target.replaceAll('#', '\\#'));
+			this.write(result.target.replaceAll('#', tool.windows ? '^#' : "\\#"));
 		}	
 		for (var result of tool.cFiles) {
 			var sourceParts = tool.splitPath(result.source);

--- a/tools/mcconfig.js
+++ b/tools/mcconfig.js
@@ -107,11 +107,12 @@ class MakeFile extends MAKEFILE {
 			this.write(sourceParts.name);
 			this.write(".h.xsi");
 		}
+
 		this.line("");
 		this.write("PRELOADS =");
 		for (var result of tool.preloads) {
 			this.write("\\\n\t-p ");
-			this.write(result);
+			this.write(result.replaceAll('#', tool.escapedHash));
 		}	
 		this.line("");
 		this.line("");

--- a/tools/mcmanifest.js
+++ b/tools/mcmanifest.js
@@ -583,9 +583,9 @@ otadata, data, ota, , ${OTADATA_SIZE},`;
 			var source = result.source;
 			var sourceParts = tool.splitPath(source);
 			var target = result.target;
-			target = target.replaceAll('#', '\\#');
 			var targetParts = tool.splitPath(target);
-			this.line("$(MODULES_DIR)", tool.slash, target, ": ", source);
+			let escapedHash = tool.windows ? "^#" : "\\#";
+			this.line("$(MODULES_DIR)", tool.slash, target.replaceAll("#", escapedHash), ": ", source.replaceAll("#", escapedHash));
 			this.echo(tool, "xsc ", target);
 			var options = "";
 			if (result.commonjs)

--- a/tools/mcmanifest.js
+++ b/tools/mcmanifest.js
@@ -635,7 +635,7 @@ otadata, data, ota, , ${OTADATA_SIZE},`;
 					options += " -c";
 				this.line("\txsc $(MODULES_DIR)", temporary, options, " -e -o $(@D) -r ", targetParts.name);
 				if (tool.windows)
-					this.line("$(MODULES_DIR)", temporary, ": TSCONFIG");
+					this.line("$(MODULES_DIR)", temporary.replaceAll("#", escapedHash), ": TSCONFIG");
 				temporaries.push("%" + temporary);
 			}
 			if (tool.windows)

--- a/tools/mcmanifest.js
+++ b/tools/mcmanifest.js
@@ -579,11 +579,11 @@ otadata, data, ota, , ${OTADATA_SIZE},`;
 			}
 		}
 
-		let escapedHash = tool.windows ? "^#" : "\\#";
+		const escapedHash = tool.windows ? "^#" : "\\#";
 
 		for (var result of tool.jsFiles) {
 			var source = result.source;
-			var sourceParts = tool.splitPath(source);
+			// var sourceParts = tool.splitPath(source);  <-- is this line needed?
 			var target = result.target;
 			var targetParts = tool.splitPath(target);
 			this.line("$(MODULES_DIR)", tool.slash, target.replaceAll("#", escapedHash), ": ", source.replaceAll("#", escapedHash));
@@ -595,7 +595,7 @@ otadata, data, ota, , ${OTADATA_SIZE},`;
 				options += " -d";
 			if (tool.nativeCode)
 				options += " -c";
-			this.line("\txsc ", source, options, " -e -o $(@D) -r ", targetParts.name);
+			this.line("\txsc ", source, options, " -e -o $(@D) -r ", targetParts.name.replaceAll("#", "\\#"));
 		}
 		this.line("");
 		

--- a/tools/mcmanifest.js
+++ b/tools/mcmanifest.js
@@ -579,14 +579,12 @@ otadata, data, ota, , ${OTADATA_SIZE},`;
 			}
 		}
 
-		const escapedHash = tool.windows ? "^#" : "\\#";
-
 		for (var result of tool.jsFiles) {
 			var source = result.source;
 			// var sourceParts = tool.splitPath(source);  <-- is this line needed?
 			var target = result.target;
 			var targetParts = tool.splitPath(target);
-			this.line("$(MODULES_DIR)", tool.slash, target.replaceAll("#", escapedHash), ": ", source.replaceAll("#", escapedHash));
+			this.line("$(MODULES_DIR)", tool.slash, target.replaceAll("#", tool.escapedHash), ": ", source.replaceAll("#", tool.escapedHash));
 			this.echo(tool, "xsc ", target);
 			var options = "";
 			if (result.commonjs)
@@ -624,7 +622,7 @@ otadata, data, ota, , ${OTADATA_SIZE},`;
 				var target = result.target;
 				var targetParts = tool.splitPath(target);
 				var temporary = source.slice(common, -3) + ".js"
-				this.line("$(MODULES_DIR)", tool.slash, target.replaceAll("#", escapedHash), ": $(MODULES_DIR)", temporary.replaceAll("#", escapedHash));
+				this.line("$(MODULES_DIR)", tool.slash, target.replaceAll("#", tool.escapedHash), ": $(MODULES_DIR)", temporary.replaceAll("#", tool.escapedHash));
 				this.echo(tool, "xsc ", target);
 				var options = "";
 				if (result.commonjs)
@@ -635,7 +633,7 @@ otadata, data, ota, , ${OTADATA_SIZE},`;
 					options += " -c";
 				this.line("\txsc $(MODULES_DIR)", temporary, options, " -e -o $(@D) -r ", targetParts.name);
 				if (tool.windows)
-					this.line("$(MODULES_DIR)", temporary.replaceAll("#", escapedHash), ": TSCONFIG");
+					this.line("$(MODULES_DIR)", temporary.replaceAll("#", tool.escapedHash), ": TSCONFIG");
 				temporaries.push("%" + temporary);
 			}
 			if (tool.windows)
@@ -1569,6 +1567,7 @@ export class Tool extends TOOL {
 		this.verbose = false;
 		this.windows = this.currentPlatform == "win";
 		this.slash = this.windows ? "\\" : "/";
+		this.escapedHash = this.windows ? "^#" : "\\#";
 
 		this.buildPath = this.moddablePath + this.slash + "build";
 		this.xsPath = this.moddablePath + this.slash + "xs";

--- a/tools/mcmanifest.js
+++ b/tools/mcmanifest.js
@@ -579,12 +579,13 @@ otadata, data, ota, , ${OTADATA_SIZE},`;
 			}
 		}
 
+		let escapedHash = tool.windows ? "^#" : "\\#";
+
 		for (var result of tool.jsFiles) {
 			var source = result.source;
 			var sourceParts = tool.splitPath(source);
 			var target = result.target;
 			var targetParts = tool.splitPath(target);
-			let escapedHash = tool.windows ? "^#" : "\\#";
 			this.line("$(MODULES_DIR)", tool.slash, target.replaceAll("#", escapedHash), ": ", source.replaceAll("#", escapedHash));
 			this.echo(tool, "xsc ", target);
 			var options = "";
@@ -623,7 +624,7 @@ otadata, data, ota, , ${OTADATA_SIZE},`;
 				var target = result.target;
 				var targetParts = tool.splitPath(target);
 				var temporary = source.slice(common, -3) + ".js"
-				this.line("$(MODULES_DIR)", tool.slash, target, ": $(MODULES_DIR)", temporary);
+				this.line("$(MODULES_DIR)", tool.slash, target.replaceAll("#", escapedHash), ": $(MODULES_DIR)", temporary.replaceAll("#", escapedHash));
 				this.echo(tool, "xsc ", target);
 				var options = "";
 				if (result.commonjs)


### PR DESCRIPTION
Two small changes to `mcconfig.js` and `mcmanifest`:

1) For Windows only, change the escaping of `#` (used for private scope modules) to use `^` symbol instead of `\`.   

2) Adjust to escape `#` only on build rules and not execution commands.  Previously it adjusted the target (and not the source) on the rule and execution command lines.  This change escapes both source and target, and only on rules.  I believe this is correct for all make systems, but I'm only able to test on Windows.

See #1354

