### PR TITLE
Merge all tsconfig properties, not just compilerOptions

### DIFF
--- a/tools/mcmanifest.js
+++ b/tools/mcmanifest.js
@@ -2073,7 +2073,7 @@ export class Tool extends TOOL {
 	mergeProperties(targets, sources, exclude) {
 		if (sources) {
 			for (let name in sources) {
-				if (exclude && exclude.includes(name))
+				if (exclude?.includes(name))
 					continue;
 				let target = targets[name];
 				let source = sources[name];

--- a/tools/mcmanifest.js
+++ b/tools/mcmanifest.js
@@ -1051,6 +1051,7 @@ export class TSConfigFile extends FILE {
 	}
 	generate(tool) {
 		let json = {
+			...tool.typescript.tsconfig,
 			compilerOptions: {
 				baseUrl: "./",
 				forceConsistentCasingInFileNames: true,
@@ -2044,6 +2045,7 @@ export class Tool extends TOOL {
 					return value;
 				});
 
+				this.mergeProperties(all.typescript.tsconfig, tsconfig, ['compilerOptions']);
 				const compilerOptions = tsconfig.compilerOptions;
 				for (let name in compilerOptions) {
 					let value = compilerOptions[name];
@@ -2068,9 +2070,11 @@ export class Tool extends TOOL {
 		}
 		return;
 	}
-	mergeProperties(targets, sources) {
+	mergeProperties(targets, sources, exclude) {
 		if (sources) {
 			for (let name in sources) {
+				if (exclude && exclude.includes(name))
+					continue;
 				let target = targets[name];
 				let source = sources[name];
 				if (target && source && (typeof target == "object") && (typeof source == "object"))
@@ -2210,7 +2214,7 @@ export class Tool extends TOOL {
 			typescript: {compiler: "tsc", tsconfig: {compilerOptions: {}}}
 		};
 		this.manifests.forEach(manifest => this.mergeManifest(this.manifest, manifest));
-
+	
 		if (this.manifest.errors.length) {
 			this.manifest.errors.forEach(error => { this.reportError(null, 0, error); });
 			throw new Error("incompatible platform!");


### PR DESCRIPTION
The manifest system allows for TypeScript settings `manifest.json` files, and merges the various`typescript.tsconfig.compilerOptions` settings into a final `tsconfig.json`.  This pull expands on that feature to merge all of the `typescript.tsconfig` section (not just `typescript.tsconfig.compilerOptions`).  

This is driven by a use case where a TypeScript transformer expects custom settings in `tsconfig.json` such as:

```json
{
    "compilerOptions": {
        "various": "typescript setting are in here"
    },
    "newTransformerTool": {
        "third-party": "options can go in here"
    }
}
```

This is a common technique used in the Node world for setting up build tools.  