### PR TITLE
Allow custom implementations of LogMachine with xsbug_log

### DIFF
--- a/documentation/tools/tools.md
+++ b/documentation/tools/tools.md
@@ -86,6 +86,8 @@ mcconfig [manifest] [-d] [-f format] [-i] [-m] [-o directory] [-p platform] [-r 
 
 > **Note**: The `-l` and `-dl` options requires Node.js on your build system. You must also first run `npm install` in `$MODDABLE/tools/xsbug-log`.
 
+> **Note**: `xsbug-log` supports an optional plug-in to allow for customizing output and control flow. Use the environment variable `XSBUG_LOGMACHINE` to set the path of a custom `LogMachine` class implementation (that extends `Machine`).  See `$MODDABLE/tools/xsbug-log/xsbug-machine.js` for the base class, and `$MODDABLE/tools/xsbug-log/xsbug-logmachine.js` for the default implementation.
+
 > **Note**: The `-dn` option is currently unsupported on Windows. It will be implemented in the near future.
 
 <a id="buildtargets"></a>

--- a/tools/xsbug-log/xsbug-logmachine.js
+++ b/tools/xsbug-log/xsbug-logmachine.js
@@ -1,0 +1,37 @@
+let Machine = require('./xsbug-machine.js').Machine;
+
+class LogMachine extends Machine {
+	view = {};
+	log = "";
+
+	onTitleChanged(title, tag) {
+		super.onTitleChanged(title, tag);
+		
+		if (title && (title !== "mcsim"))
+			console.log(`#xsbug-log connected to "${title}"`);
+
+		this.doSetAllBreakpoint([], false, true);		// break on exceptions
+	}
+	onLogged(path, line, data) {
+		this.log += data;
+		if (this.log.endsWith("\n")) {
+			console.log(this.log.slice(0, this.log.length - 1));
+			this.log = "";
+		}
+	}
+	onBroken(path, line, text) {
+		this.view.frames.forEach((frame, index) => {
+			let line = "  #" + index + ": " + frame.name;
+			if (frame.path)
+				line += " " + frame.path + ":" + frame.line
+			console.log(line);
+		});
+
+		super.onBroken(path, line, text);
+	}
+	onViewChanged(name, items) {
+		this.view[name] = items;
+	}
+}
+
+exports.LogMachine = LogMachine;


### PR DESCRIPTION
This PR is a proposal to add a tiny bit of extensibility to `xsbug_log` by allowing the `LogMachine` class to be overridden by an external module.  Changes include:

* Pulled `LogMachine` out to it's own file `xsbug-logmachine`
* Added check if the `XSBUG_LOGMACHINE` environment variable is set and if so load that as the module for `LogMachine` (else defaults to the original version)
* Bit of documentation in the associated xsbug readme

I am requesting this change for a couple of reasons:

1) Support for colorization using the \<info>, \<warn>, ... tags
    > I'm glad to provide this if interested, either as an update to the default `LogMachine` or as an optional one such as `xsbug-colorlogmachine.js` that can be selected with `XSBUG_LOGMACHINE`
2) I have a custom test runner, similar in concept to what `xsbug` does but unique to fit my needs, and I'm using `xsbug-log` to manage the logging and tracking of test executions.