### PR TITLE
Fix typo in MODDEF_FILE_LFS_PARTITION_SIZE

### DIFF
--- a/documentation/files/files.md
+++ b/documentation/files/files.md
@@ -435,8 +435,8 @@ The backing store for littlefs varies depending the host platform:
 
 - **ESP32** - littlefs uses the "storage" partition to hold the file system.
 - **ESP8266** - the file system is stored in the upper 3 MB of flash (the same area used by SPIFFS).
-- **nRF52** - littlefs uses the free space following the firmware image and installed mod. The default size is 64 KB, which may be overridden by `MODDEF_FILE_LFS_PARITION_SIZE` in the manifest `defines`. If there is not enough space, an exception is thrown when accessing the file system.
-- **Others**, littlefs uses a static memory buffer to hold the file system. The default size is 64 KB, which may be overridden by `MODDEF_FILE_LFS_PARITION_SIZE` in the manifest. This RAM disk mode allows littlefs to be used with the simulator.
+- **nRF52** - littlefs uses the free space following the firmware image and installed mod. The default size is 64 KB, which may be overridden by `MODDEF_FILE_LFS_PARTITION_SIZE` in the manifest `defines`. If there is not enough space, an exception is thrown when accessing the file system.
+- **Others**, littlefs uses a static memory buffer to hold the file system. The default size is 64 KB, which may be overridden by `MODDEF_FILE_LFS_PARTITION_SIZE` in the manifest. This RAM disk mode allows littlefs to be used with the simulator.
 
 ```json
 	"defines": {

--- a/modules/files/file/littlefs/modLittlefs.c
+++ b/modules/files/file/littlefs/modLittlefs.c
@@ -54,8 +54,8 @@
 #ifndef MODDEF_FILE_LFS_BLOCK_CYCLES
 	#define MODDEF_FILE_LFS_BLOCK_CYCLES 500
 #endif
-#ifndef MODDEF_FILE_LFS_PARITION_SIZE  
-	#define MODDEF_FILE_LFS_PARITION_SIZE (65536)
+#ifndef MODDEF_FILE_LFS_PARTITION_SIZE  
+	#define MODDEF_FILE_LFS_PARTITION_SIZE (65536)
 #endif
 
 #ifdef __ets__
@@ -67,7 +67,7 @@
 	#define MOD_LFS_RAMDISK 1
 
 	#define kBlockSize (4096)
-	#define kBlockCount ((MODDEF_FILE_LFS_PARITION_SIZE + kBlockSize - 1) / kBlockSize)
+	#define kBlockCount ((MODDEF_FILE_LFS_PARTITION_SIZE + kBlockSize - 1) / kBlockSize)
 	
 	uint8_t gRAMDisk[kBlockSize * kBlockCount]; 
 #endif

--- a/modules/io/files/littlefs/files-littlefs.c
+++ b/modules/io/files/littlefs/files-littlefs.c
@@ -54,8 +54,8 @@
 #ifndef MODDEF_FILE_LFS_BLOCK_CYCLES
 	#define MODDEF_FILE_LFS_BLOCK_CYCLES 500
 #endif
-#ifndef MODDEF_FILE_LFS_PARITION_SIZE  
-	#define MODDEF_FILE_LFS_PARITION_SIZE (131072)
+#ifndef MODDEF_FILE_LFS_PARTITION_SIZE  
+	#define MODDEF_FILE_LFS_PARTITION_SIZE (131072)
 #endif
 
 #ifdef __ets__
@@ -67,7 +67,7 @@
 	#define MOD_LFS_RAMDISK 1
 
 	#define kBlockSize (4096)
-	#define kBlockCount ((MODDEF_FILE_LFS_PARITION_SIZE + kBlockSize - 1) / kBlockSize)
+	#define kBlockCount ((MODDEF_FILE_LFS_PARTITION_SIZE + kBlockSize - 1) / kBlockSize)
 
 	uint8_t gRAMDisk[kBlockSize * kBlockCount]; 
 #endif


### PR DESCRIPTION
The RAM disk for LittleFS has it's [RAM disk size](https://github.com/Moddable-OpenSource/moddable/blob/3bf520227129bd7f4445f2422b18335346294db5/documentation/files/files.md#littlefs) set with:

```
	"defines": {
		"file": {
			"lfs": {
				"partition_size": 131072
			}
		}
	}
```

which translates to the macro `MODDEF_FILE_LFS_PARTITION_SIZE`.  However, the code was consistently implemented with a typo in the name, as `MODDEF_FILE_LFS_PARITION_SIZE` (missing a 'T').  This PR fixes all uses of the macro name.