### PR TITLE
Additional Fix typo in documentation/commodetto/poco.md

### DIFF
--- a/documentation/commodetto/poco.md
+++ b/documentation/commodetto/poco.md
@@ -960,7 +960,7 @@ void PocoBitmapDrawMasked(Poco poco, PocoBitmap bits, uint8_t blend,
 		PocoBitmap mask, PocoDimension mask_sx, PocoDimension mask_sy);
 ```
 
-`PocoBitmapDrawMasked` renders the pixels of bitmap `bits`, of type `kCommodettoBitmapDefault`, enclosed by `sx`, `sy`, `sw`, and `sh` at the location specified by `x` and `y`. The pixels are drawn using the corresponding pixels of the bitmap `mask`, of type `kCommodettoBitmapGray16`, enclosed by `mask_x`, `mask_y`, `sw`, and `sh` as alpha blending levels. The `blend` argument is applied to the blend level of each pixel, with values ranging from 0 for transparent to 255 for opaque.
+`PocoBitmapDrawMasked` renders the pixels of bitmap `bits`, of type `kCommodettoBitmapDefault`, enclosed by `sx`, `sy`, `sw`, and `sh` at the location specified by `x` and `y`. The pixels are drawn using the corresponding pixels of the bitmap `mask`, of type `kCommodettoBitmapGray16`, enclosed by `mask_sx`, `mask_sy`, `sw`, and `sh` as alpha blending levels. The `blend` argument is applied to the blend level of each pixel, with values ranging from 0 for transparent to 255 for opaque.
 
 ***
 
@@ -974,7 +974,7 @@ void PocoBitmapPattern(Poco poco, PocoBitmap bits,
 		PocoDimension sw, PocoDimension sh);
 ```
 
-`PocoBitmapPattern ` fills the area enclosed by the `x`, `y`, `w`, and `h` arguments with repeating copies of the area of the bitmap `bits` enclosed by the `sx`, `sy`, `sw`, and `sh` arguments. The bitmap must be of type `kCommodettoBitmapDefault`.
+`PocoBitmapPattern` fills the area enclosed by the `x`, `y`, `w`, and `h` arguments with repeating copies of the area of the bitmap `bits` enclosed by the `sx`, `sy`, `sw`, and `sh` arguments. The bitmap must be of type `kCommodettoBitmapDefault`.
 
 ***
 
@@ -1040,17 +1040,17 @@ void PocoDrawingBeginFrameBuffer(Poco poco, PocoCoordinate x, PocoCoordinate y,
 	PocoPixel *pixels, int16_t rowBytes);
 ```
 
-`PocoDrawingBeginFrameBuffer ` begins the immediate mode rendering process for an update area of pixels bounded by the `x`, `y`, `w`, and `h` parameters. The `pixels` parameter points to the first scanline of output pixels. The `rowBytes` parameters is the stride in bytes between each scanline.
+`PocoDrawingBeginFrameBuffer` begins the immediate mode rendering process for an update area of pixels bounded by the `x`, `y`, `w`, and `h` parameters. The `pixels` parameter points to the first scanline of output pixels. The `rowBytes` parameters is the stride in bytes between each scanline.
 
 ***
 
 ##### `PocoDrawingEndFrameBuffer`
 
 ```c
-int PocoDrawingEndFrameBuffer(Poco poco;
+int PocoDrawingEndFrameBuffer(Poco poco);
 ```
 
-`PocoDrawingEndFrameBuffer ` indicates that all drawing is complete for the current frame.
+`PocoDrawingEndFrameBuffer` indicates that all drawing is complete for the current frame.
 
 ***
 


### PR DESCRIPTION
Hello,

This pull request addresses additional typos found in `documentation/commodetto/poco.md`. 
(Apologies for this being separate from the previous pull request #1375.)

- Corrected the argument names to `mask_sx`, `mask_sy` instead of `mask_x`, `mask_y`.
- Removed unnecessary spaces for better formatting.
- Added missing closing parentheses.

Thank you.

Note: This message has been created using machine translation.