### PR TITLE
change DEBUGGER_SPEED of m5stack_core2 (#1359)

### DIFF
--- a/build/devices/esp32/targets/m5stack_core2/manifest.json
+++ b/build/devices/esp32/targets/m5stack_core2/manifest.json
@@ -1,7 +1,7 @@
 {
 	"build": {
 		"UPLOAD_SPEED": "1500000",
-		"DEBUGGER_SPEED": "1500000",
+		"DEBUGGER_SPEED": "921600",
 		"SDKCONFIGPATH": "./sdkconfig",
 		"PARTITIONS_FILE_FOR_TARGET": "./sdkconfig/partitions.csv"
 	},

--- a/examples/manifest_mod.json
+++ b/examples/manifest_mod.json
@@ -107,7 +107,7 @@
 		"esp32/m5stack_core2": {
 			"build": {
 				"UPLOAD_SPEED": "1500000",
-				"DEBUGGER_SPEED": "1500000"
+				"DEBUGGER_SPEED": "921600"
 			}
 		},
 		"esp32/m5stack_cores3": {


### PR DESCRIPTION
I don’t know the end of this issue, but other users also encountered the same issue of not being able to run mod, and this has been resolved through this change.