### PR TITLE
Resolve crash in xsbug-log when using Workers

### DIFF
--- a/tools/xsbug-log/xsbug-machine.js
+++ b/tools/xsbug-log/xsbug-machine.js
@@ -47,6 +47,14 @@ class Machine {
 		this.output = output;
 		this.profile = new Profile();
 		this.profiling = false;
+
+		input.on('error', (err) => {
+			input.unpipe(parser);
+		});
+
+		input.on('close', () => {
+			input.unpipe(parser);
+		});
 	}
 	
 	onStartElement(name, attributes) {


### PR DESCRIPTION
When using `mcconfig -dl` (`xsbug-log`) with a program that uses `Worker`, each worker will make a new connection to `xsbug-log`.  When the worker is done, it tears down the connection and `xsbug-log` does not have handlers for the connection reset and it crashes with the following:

```
node:events:497
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:218:20)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:169:8)
    at emitErrorCloseNT (node:internal/streams/destroy:128:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -4077,
  code: 'ECONNRESET',
  syscall: 'read'
}
```

This PR adds event handlers for the  `error` and `close` events, and cleanly unpipes from `Saxaphore`, thereby resolving the issue.