### PR TITLE
Improve Instrumentation typings

### DIFF
--- a/typings/instrumentation.d.ts
+++ b/typings/instrumentation.d.ts
@@ -1,60 +1,50 @@
 /*
-* Copyright (c) 2019-2020 Bradley Farias
-*
-*   This file is part of the Moddable SDK Tools.
-*
-*   The Moddable SDK Tools is free software: you can redistribute it and/or modify
-*   it under the terms of the GNU General Public License as published by
-*   the Free Software Foundation, either version 3 of the License, or
-*   (at your option) any later version.
-*
-*   The Moddable SDK Tools is distributed in the hope that it will be useful,
-*   but WITHOUT ANY WARRANTY; without even the implied warranty of
-*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*   GNU General Public License for more details.
-*
-*   You should have received a copy of the GNU General Public License
-*   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
-*
-*/
+ * Copyright (c) 2019-2020 Bradley Farias
+ *
+ *   This file is part of the Moddable SDK Tools.
+ *
+ *   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Tools is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
-declare module "instrumentation" {
-  type PixelsDrawn = 1;
-  type FramesDrawn = 2;
-  type NetworkBytesRead = 3;
-  type NetworkBytesWritten = 4;
-  type NetworkSockets = 5;
-  type Timers = 6;
-  type Files = 7;
-  type POCODisplayListUsed = 8;
-  type PIUCommandListUsed = 9;
-  type SystemFreeMemory = 10;
-  type SlotHeapSize = 11;
-  type ChunkHeapSize = 12;
-  type KeysUsed = 13;
-  type GarbageCollectionCount = 14;
-  type ModulesLoaded = 15;
-  type StackPeak = 16;
-  type InstrumentationOption = (
-    PixelsDrawn |
-    FramesDrawn |
-    NetworkBytesRead |
-    NetworkBytesWritten |
-    NetworkSockets |
-    Timers |
-    Files |
-    POCODisplayListUsed |
-    PIUCommandListUsed |
-    SystemFreeMemory |
-    SlotHeapSize |
-    ChunkHeapSize |
-    KeysUsed |
-    GarbageCollectionCount |
-    ModulesLoaded |
-    StackPeak
-  );
-  var Instrumentation: {
-   get: (what: InstrumentationOption) => number;
-  };
-  export {Instrumentation as default};
+declare module 'instrumentation' {
+	type InstrumentationKeys =
+		| 'Pixels Drawn'
+		| 'Frames Drawn'
+		| 'Network Bytes Read'
+		| 'Network Bytes Written'
+		| 'Network Sockets'
+		| 'Timers'
+		| 'Files'
+		| 'Poco Display List Used'
+		| 'Piu Command List Used'
+		| 'Turns'
+		| 'CPU 0'
+		| 'CPU 1'
+		| 'System Free Memory'
+		| 'XS Slot Heap Used'
+		| 'XS Chunk Heap Used'
+		| 'XS Keys Used'
+		| 'XS Garbage Collection Count'
+		| 'XS Modules Loaded'
+		| 'XS Stack Used'
+		| 'XS Promises Settled';
+
+	var Instrumentation: {
+		get: (what: number | undefined) => number | undefined;
+		map: (name: InstrumentationKeys) => number | undefined;
+		name: (what: number | undefined) => string | undefined;
+	};
+	export { Instrumentation as default };
 }


### PR DESCRIPTION
This PR updates the `.d.ts` for `Instrumentation`.  It adds the `map` and `name` methods, removes the old numeric types for all the instrumentation (which were incorrect depending on the platform/configuration), and adds a new string literal union type with the names of the instruments for use with `map`.  It also allows for `number | undefined` for the index to nested operations such as `Instrumentation.get(Instrumentation.map('Network Bytes Read'))` which otherwise would be a type error.