### PR TITLE
add function define for AudioOut.Volume

### DIFF
--- a/typings/pins/audioout.d.ts
+++ b/typings/pins/audioout.d.ts
@@ -53,6 +53,7 @@ declare module 'pins/audioout' {
     public enqueue(stream: number, kind: MixerKind, buffer: HostBuffer, repeat: number, offset: number, count: number): void
     public enqueue(stream: number, kind: MixerTone, frequency: number, samples: number): void
     public enqueue(stream: number, kind: MixerSilence, samples: number): void
+    public enqueue(stream: number, kind: MixerVolume, volume: number): void
     
     public mix(samplesNeeded: number): HostBuffer
     public mix(buffer: BufferLike): void


### PR DESCRIPTION
It handles cases where [AudioOut.Volume](https://github.com/Moddable-OpenSource/moddable/blob/24e3e54fd3b66379c1f91ad92969c99f941ff4cf/documentation/pins/audioout.md#changing-volume) is used as follows.

```
audio.enqueue(0, AudioOut.Volume, 128);
```