### PR TITLE
Typings for Time.microseconds

### DIFF
--- a/typings/time.d.ts
+++ b/typings/time.d.ts
@@ -27,6 +27,7 @@ declare module "time" {
     dst: number;
     ticks: number;
     delta(start: number, end?: number): number;
+    readonly microseconds?: number;
   }
   export {Time as default};
 }


### PR DESCRIPTION
Added `microseconds` to `Time` type definitions.

I spent too much time debating this implementation with myself! The simple solution is to add it as another property and leave it up to the user to decide if they wish to use it or not (without any TS-level validation, as in `readonly microseconds: number`). A more complex solution would be to create a separate `.d.ts` file that extends `Time` and change the manifest to include it for the platforms that implement `microseconds`. But that turns into an ugly build problem for consumers of it - for example, code using microseconds for ESP32 would fail to build on simulator requiring breaking apart source files and adjusting manifest files when otherwise you could have done a runtime check.

I ended up marking it optional (`readonly microseconds?: number`), which with TS strict on would require you to check it but without strict it will just allow the access. This seemed to most closely match how the JS implementation works, and allows the simple pattern of `Time.microseconds ?? Time.ticks * 1000` if you wish to emulate it.