### PR TITLE
Use CONFIG_ESP_CONSOLE_UART_BAUDRATE for instrumented ESP32 builds

### DIFF
--- a/build/devices/esp32/xsProj-esp32/main/main.c
+++ b/build/devices/esp32/xsProj-esp32/main/main.c
@@ -240,7 +240,7 @@ void app_main() {
 #ifdef mxDebug
 	uartConfig.baud_rate = DEBUGGER_SPEED;
 #else
-	uartConfig.baud_rate = 115200;		//@@ different from ESP8266
+	uartConfig.baud_rate = CONFIG_ESP_CONSOLE_UART_BAUDRATE;		//@@ different from ESP8266
 #endif
 	uartConfig.data_bits = UART_DATA_8_BITS;
 	uartConfig.parity = UART_PARITY_DISABLE;

--- a/build/devices/esp32/xsProj-esp32c3/main/main.c
+++ b/build/devices/esp32/xsProj-esp32c3/main/main.c
@@ -276,7 +276,7 @@ void app_main() {
 #ifdef mxDebug
 	uartConfig.baud_rate = DEBUGGER_SPEED;
 #else
-	uartConfig.baud_rate = 115200;		//@@ different from ESP8266
+	uartConfig.baud_rate = CONFIG_ESP_CONSOLE_UART_BAUDRATE;		//@@ different from ESP8266
 #endif
 	uartConfig.data_bits = UART_DATA_8_BITS;
 	uartConfig.parity = UART_PARITY_DISABLE;

--- a/build/devices/esp32/xsProj-esp32c6/main/main.c
+++ b/build/devices/esp32/xsProj-esp32c6/main/main.c
@@ -281,7 +281,7 @@ void app_main() {
 #ifdef mxDebug
 	uartConfig.baud_rate = DEBUGGER_SPEED;
 #else
-	uartConfig.baud_rate = 115200;		//@@ different from ESP8266
+	uartConfig.baud_rate = CONFIG_ESP_CONSOLE_UART_BAUDRATE;		//@@ different from ESP8266
 #endif
 	uartConfig.data_bits = UART_DATA_8_BITS;
 	uartConfig.parity = UART_PARITY_DISABLE;

--- a/build/devices/esp32/xsProj-esp32h2/main/main.c
+++ b/build/devices/esp32/xsProj-esp32h2/main/main.c
@@ -281,7 +281,7 @@ void app_main() {
 #ifdef mxDebug
 	uartConfig.baud_rate = DEBUGGER_SPEED;
 #else
-	uartConfig.baud_rate = 115200;		//@@ different from ESP8266
+	uartConfig.baud_rate = CONFIG_ESP_CONSOLE_UART_BAUDRATE;		//@@ different from ESP8266
 #endif
 	uartConfig.data_bits = UART_DATA_8_BITS;
 	uartConfig.parity = UART_PARITY_DISABLE;

--- a/build/devices/esp32/xsProj-esp32s2/main/main.c
+++ b/build/devices/esp32/xsProj-esp32s2/main/main.c
@@ -225,7 +225,7 @@ void setup(void)
 #ifdef mxDebug
 	uartConfig.baud_rate = DEBUGGER_SPEED;
 #else
-	uartConfig.baud_rate = 115200;		//@@ different from ESP8266
+	uartConfig.baud_rate = CONFIG_ESP_CONSOLE_UART_BAUDRATE;		//@@ different from ESP8266
 #endif
 	uartConfig.data_bits = UART_DATA_8_BITS;
 	uartConfig.parity = UART_PARITY_DISABLE;

--- a/build/devices/esp32/xsProj-esp32s3/main/main.c
+++ b/build/devices/esp32/xsProj-esp32s3/main/main.c
@@ -491,7 +491,7 @@ void app_main() {
 #ifdef mxDebug
 	uartConfig.baud_rate = DEBUGGER_SPEED;
 #else
-	uartConfig.baud_rate = 115200;		//@@ different from ESP8266
+	uartConfig.baud_rate = CONFIG_ESP_CONSOLE_UART_BAUDRATE;		//@@ different from ESP8266
 #endif
 	uartConfig.data_bits = UART_DATA_8_BITS;
 	uartConfig.parity = UART_PARITY_DISABLE;


### PR DESCRIPTION
Update to all ESP32 `main.c` to use `CONFIG_ESP_CONSOLE_UART_BAUDRATE` instead of the hard-coded 115200 for instrumented builds (brief discussion on #1409).