### PR TITLE
TypeScript type adjustments for Socket and Worker

### DIFF
--- a/typings/socket.d.ts
+++ b/typings/socket.d.ts
@@ -86,6 +86,7 @@ declare module "socket" {
     constructor(options: ListenerOptions);
     callback: (this: Listener) => void;
   }
+  type Socket = RawSocket | TCPSocket | UDPSocket;
   var Socket: {
     new <T extends RawSocketOptions | TCPSocketOptions | UDPSocketOptions>(
       dictionary: T

--- a/typings/worker.d.ts
+++ b/typings/worker.d.ts
@@ -19,21 +19,45 @@
  */
 
 declare module "worker" {
-	export interface Self {
+	export interface WorkerOptions {
+		static?: number;
+		chunk?: {
+			initial: number;
+			incremental: number;
+		};
+		heap?: {
+			initial: number;
+			incremental: number;
+		};
+		stack?: number;
+		keys?: {
+			initial: number;
+			incremental: number;
+			name: string;
+			symbol: string;
+		};
+	}
+
+	interface MessagePort {
 		onmessage(message: any): void;
 		postMessage(message: any): void;
 	}
 
-	class Worker implements Self  {
-		constructor(module: string, options?: object)
-		terminate(): void;
-
+	class Worker implements MessagePort {
+		constructor(module: string, options?: WorkerOptions)
 		onmessage(message: any): void;
 		postMessage(message: any): void;
+		terminate(): void;
 	}
 
 	export class SharedWorker {
 		constructor(module: string, options?: object)
+		get port(): MessagePort
+	}
+
+
+	export interface Self extends MessagePort {
+		close(): void;
 	}
 
 	global {

--- a/typings/worker.d.ts
+++ b/typings/worker.d.ts
@@ -22,19 +22,19 @@ declare module "worker" {
 	export interface WorkerOptions {
 		static?: number;
 		chunk?: {
-			initial: number;
-			incremental: number;
+			initial?: number;
+			incremental?: number;
 		};
 		heap?: {
-			initial: number;
-			incremental: number;
+			initial?: number;
+			incremental?: number;
 		};
 		stack?: number;
 		keys?: {
-			initial: number;
-			incremental: number;
-			name: string;
-			symbol: string;
+			initial?: number;
+			incremental?: number;
+			name?: number;
+			symbol?: number;
 		};
 	}
 

--- a/xs/includes/xs.d.ts
+++ b/xs/includes/xs.d.ts
@@ -62,7 +62,7 @@ interface ArrayBufferConstructor {
 }
 
 interface ArrayBuffer {
-	concat?(...buffers: ArrayBufferLike[]): ArrayBuffer;
+	concat(...buffers: ArrayBufferLike[]): ArrayBuffer;
 }
 
 interface BigIntConstructor {

--- a/xs/includes/xs.d.ts
+++ b/xs/includes/xs.d.ts
@@ -62,7 +62,7 @@ interface ArrayBufferConstructor {
 }
 
 interface ArrayBuffer {
-	concat(...buffers: ArrayBufferLike[]): ArrayBuffer;
+	concat?(...buffers: ArrayBufferLike[]): ArrayBuffer;
 }
 
 interface BigIntConstructor {


### PR DESCRIPTION
Three typescript `.d.ts` file changes:

* `socket.d.ts`: define a type for `Socket`
~~* `xs.d.ts`: Make `concat` on `ArrayBuffer` optional as it isn't always available on the various `ArrayBufferLike` types.~~
* `worker.d.ts`: Strengthed the worker types, including adding the creation properties.

(Edited to remove the `xs.d.ts` changes, per discussion below)