### PR TITLE
fix: change `Headers` type to use `string` instead of `String` to resolve type error

### DIFF
--- a/typings/headers.d.ts
+++ b/typings/headers.d.ts
@@ -19,7 +19,7 @@
 */
 
 declare module "headers" {
-    class Headers extends Map<String, String> {}
+    class Headers extends Map<string, string> {}
 
     export { Headers as default };
 }


### PR DESCRIPTION
The current type declaration used `String`, which caused an incompatibility error (TS2322) when assigning `Headers` to `Map<string, string | string[]>`. Changed to use `string` as it is the appropriate primitive type.