### PR TITLE
fix the type definition of the read function in AudionIn.

### DIFF
--- a/typings/pins/audioin.d.ts
+++ b/typings/pins/audioin.d.ts
@@ -22,7 +22,7 @@ declare module 'pins/audioin' {
   class AudioIn {
     public constructor()
     public close(): void
-    public read(samples: number): number
+    public read(sampleCount: number, buffer?: ArrayBuffer, offset?: number): ArrayBuffer
     public readonly sampleRate: number
     public readonly bitsPerSample: number
     public readonly numChannels: number


### PR DESCRIPTION
I noticed that the `read` function takes [a second and third argument.](https://github.com/stc1988/moddable/blob/public/modules/pins/audioin/esp32/audioin.c#L219-L230) and the type of return value is `ArrayBuffer`. 

I will make this correction in this PR. 
cc: @meganetaaan 