### PR TITLE
[Enhancement] Added configuration of camera parameter

### DIFF
--- a/examples/io/imagein/camera/camera-server-jpeg/main.js
+++ b/examples/io/imagein/camera/camera-server-jpeg/main.js
@@ -18,11 +18,13 @@ import Camera from "embedded:x-io/imagein/camera";
 import Net from "net";
 
 let width = 176, height = 144;
+let xclock = 20000000;
 let frame;
 
 const camera = new Camera({
 	width,
 	height,
+	xclock,
 	imageType: "jpeg",
 	format: "buffer/disposable",
 	onReadable: () => {

--- a/modules/io/imagein/camera/esp32/camera.c
+++ b/modules/io/imagein/camera/esp32/camera.c
@@ -336,6 +336,7 @@ void xs_camera_constructor(xsMachine *the)
 	Camera camera;
 	int imageType = kCommodettoBitmapRGB565LE;
 	uint8_t isJPEG = 0;
+	uint32_t xclock = 24000000;
 
 	xsmcVars(1);
 
@@ -362,6 +363,11 @@ void xs_camera_constructor(xsMachine *the)
 		else
 			imageType = xsmcToInteger(xsVar(0));
 	}
+	if (xsmcHas(xsArg(0), xsID_xclock)) {
+                xsmcGet(xsVar(0), xsArg(0), xsID_xclock);
+                xclock = xsmcToInteger(xsVar(0));
+		camera_config.xclk_freq_hz = xclock;
+        }
 
 	camera = c_calloc(1, sizeof(CameraRecord));
 	if (!camera)


### PR DESCRIPTION
camera_config.xclk_freq_hz is hardcoded in camera.c as 24000000.
It needs to define xclk_freq_hz as 20000000 below on OV3660 camera device.

I tried sample camera programs as camera-server-jpeg and camera-server-motion-jpeg on XIAO ESP32S3 Sense and M5Atom S3R M12.

* XIAO ESP32S3 Sense
OV2640 camera device
https://www.seeedstudio.com/XIAO-ESP32S3-Sense-p-5639.html

* M5Atom S3R M12
OV3660 camera device
https://docs.m5stack.com/en/core/AtomS3R-M12

OV2640 works fine for me, but OV3660 does not work correctly.
OV3660 outputs corrupted JPEG data with xclk_freq_hz as 24000000.
![corrupt](https://github.com/user-attachments/assets/90b2c716-9273-478a-b79e-016050a57e02)

I checked esp_camera.h in ESP32-Camera repository and tried a parameter same as xclk_freq_hz.
It works fine with 20000000.
https://raw.githubusercontent.com/espressif/esp32-camera/4335c93ec462a379aa2a3d655b8834972d725190/driver/include/esp_camera.h