### PR TITLE
Fix the type definition of Bytes.

### DIFF
--- a/typings/ble/btutils.d.ts
+++ b/typings/ble/btutils.d.ts
@@ -34,7 +34,8 @@ type ManufacturerSpec = {
 
 declare module "btutils" {
 
-  export interface Bytes extends ArrayBuffer {
+  export class Bytes extends ArrayBuffer {
+    constructor(bytes: string | ArrayBufferLike, littleEndian?: boolean)
     /**
      * The `equals` function returns `true` if the instance
      * ArrayBuffer data equals the data contained in `buffer`.


### PR DESCRIPTION
 I split the definition of ble in #1452  , but the definition of [Bytes](https://github.com/Moddable-OpenSource/moddable/blob/public/modules/network/ble/btutils.js#L131-L163) does not match the implementation, so it will be corrected.



