### PR TITLE
add typing  embedded:io/audio/in and embedded:io/audio/out

### DIFF
--- a/typings/embedded_io/audioin.d.ts
+++ b/typings/embedded_io/audioin.d.ts
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2025 Satoshi Tanaka
+*
+*   This file is part of the Moddable SDK Tools.
+*
+*   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   The Moddable SDK Tools is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+declare module "embedded:io/audio/in" {
+  import { Buffer } from "embedded:io/_common";
+
+  type AudioType = "LPCM";
+
+  interface AudioInOptions {
+    bitsPerSample?: 8 | 16;
+    channels?: 1 | 2;
+    sampleRate?: number;
+    audioType?: AudioType;
+    format?: "buffer";
+  }
+
+  class AudioIn {
+    constructor(options: AudioInOptions & {
+      onReadable?: (this: AudioIn, bytes: number) => void;
+    });
+    read(byteLength?: number): ArrayBuffer
+    read(buffer: Buffer): void;
+    start(): void;
+    stop(flush?: boolean): void;
+    close(): void;
+    readonly bitsPerSample: 8 | 16;
+    readonly channels: 1 | 2;
+    readonly sampleRate: number;
+    readonly audioType: AudioType;
+    get format(): "buffer"
+    set format(value: "buffer")
+  }
+
+  export { AudioIn as default };
+}

--- a/typings/embedded_io/audioin.d.ts
+++ b/typings/embedded_io/audioin.d.ts
@@ -28,16 +28,17 @@ declare module "embedded:io/audio/in" {
     sampleRate?: number;
     audioType?: AudioType;
     format?: "buffer";
+    target?: any;
   }
 
   class AudioIn {
     constructor(options: AudioInOptions & {
-      onReadable?: (this: AudioIn, bytes: number) => void;
+      onReadable?: (this: AudioIn, byteLength: number, sampleCount?: number) => void;
     });
     read(byteLength?: number): ArrayBuffer
-    read(buffer: Buffer): void;
+    read(buffer: Buffer): number
     start(): void;
-    stop(flush?: boolean): void;
+    stop(options?: { flush?: boolean }): void
     close(): void;
     readonly bitsPerSample: 8 | 16;
     readonly channels: 1 | 2;

--- a/typings/embedded_io/audioout.d.ts
+++ b/typings/embedded_io/audioout.d.ts
@@ -28,10 +28,13 @@ declare module "embedded:io/audio/out" {
     sampleRate?: number;
     audioType?: AudioType;
     format?: "buffer";
+    target?: any;
   }
 
   class AudioOut {
-    constructor(options?: AudioOutOptions);
+    constructor(options?: AudioOutOptions & {
+      onWritable?: (this: AudioOut, byteLength: number, sampleCount?: number) => void;
+    });
     write(buffer: Buffer): void;
     start(): void;
     stop(options?: { flush?: boolean }): void;

--- a/typings/embedded_io/audioout.d.ts
+++ b/typings/embedded_io/audioout.d.ts
@@ -1,0 +1,49 @@
+/*
+* Copyright (c) 2025 Satoshi Tanaka
+*
+*   This file is part of the Moddable SDK Tools.
+*
+*   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   The Moddable SDK Tools is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+declare module "embedded:io/audio/out" {
+  import { Buffer } from "embedded:io/_common";
+
+  type AudioType = "LPCM";
+
+  interface AudioOutOptions {
+    bitsPerSample?: 8 | 16;
+    channels?: 1 | 2;
+    sampleRate?: number;
+    audioType?: AudioType;
+    format?: "buffer";
+  }
+
+  class AudioOut {
+    constructor(options?: AudioOutOptions);
+    write(buffer: Buffer): void;
+    start(): void;
+    stop(options?: { flush?: boolean }): void;
+
+    readonly audioType: AudioType;
+    readonly bitsPerSample: 8 | 16;
+    readonly channels: 1 | 2;
+    readonly sampleRate: number;
+    get format(): "buffer"
+    set format(value: "buffer")
+    volume: number;
+  }
+
+  export { AudioOut as default };
+}


### PR DESCRIPTION
This PR adds typings for `embedded:io/audio/in` and `embedded:io/audio/out`