### PR TITLE
instructions option  for openai-stream

### DIFF
--- a/contributed/conversationalAI/readme.md
+++ b/contributed/conversationalAI/readme.md
@@ -22,9 +22,9 @@ mcconfig -d -m -p esp32/moddable_six_cdc openAIKey="xyzzy" geminiAPIKey="abcde"
 You can also add the keys to your environment, so that they can be accessed by name.
 
 ```
-export openAIKey="xyzzy"
-export geminiAPIKey ="abcde"
-mcconfig -d -m -p esp32/moddable_six_cdc openAIKey=$openAIKey geminiAPIKey=$geminiAPIKey
+export OPENAI_API_KEY="xyzzy"
+export GEMINI_API_KEY ="abcde"
+mcconfig -d -m -p esp32/moddable_six_cdc openAIKey=$OPENAI_API_KEY geminiAPIKey=$GEMINI_API_KEY
 ```
 
 ### Wi-Fi
@@ -52,12 +52,12 @@ The bitmap fonts are created as part of the build process from TrueType fonts in
 
 ## Compatibility
 
-Conversational AI is incredibly efficient, but it still requires more resources, particularly RAM, than some embedded devices have. We've primarily tested on ESP32-S3 devices with extended memory (PSRAM). 2 MB of extended PSRAM should be enough, though many devices now provide 8 MB. Moddable Six is our favorite, but others work (or could work with a little input or output driver configuration work). 
+Conversational AI is incredibly efficient, but it still requires more resources, particularly RAM, than some embedded devices have. We've primarily tested on ESP32-S3 devices with extended memory (PSRAM). 2 MB of extended PSRAM should be enough, though many devices now provide 8 MB. Moddable Six is our favorite, but others work (or could work with a little input or output driver configuration work).
 
 ## Simulator
 
 You can also run Conversational AI on the Moddable SDK's built-in simulator, `mcsim`. This is a great way to explore how the code works and even develop new features. The simulator is available on macOS, Windows, and Linux. To build and run, just use the Moddable Six simulator target with your AI service keys:
 
 ```
-mcconfig -d -m -p sim/moddable_six openAIKey=$openAIKey geminiAPIKey=$geminiAPIKey
+mcconfig -d -m -p sim/moddable_six openAIKey=$OPENAI_API_KEY geminiAPIKey=$GEMINI_API_KEY
 ```

--- a/examples/pins/audioout/openai-stream/openaistreamer.js
+++ b/examples/pins/audioout/openai-stream/openaistreamer.js
@@ -25,13 +25,14 @@ import WavStreamer from "wavstreamer";
 
 export default class {
 	constructor(options) {
-		const {key, model, voice, input, speed, response_format, ...o} = options;
+		const {key, model, voice, input, speed, response_format, instructions,...o} = options;
 		const request = {
 			input,
 			model,
 			voice,
 			speed: speed ?? 1,
 			response_format: response_format ?? "mp3",
+			instructions,
 		};
 		const body = ArrayBuffer.fromString(JSON.stringify(request));
 		let streamer;


### PR DESCRIPTION
In OpenAI’s latest [announcement](https://openai.com/index/introducing-our-next-generation-audio-models/), a new audio model was introduced.
This PR adds an `instructions` option that can be used with the `gpt-4o-mini-tts` model for text-to-speech.

I also confirmed that the Realtime API allows specifying a model for transcription and that it works, but since Gemini didn’t have a similar option, I didn’t extend `chatAudioIO`.

