### PR TITLE
ignore dist directory generated by tsc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ build/devices/qca4020/xsProj/build/gcc/output/
 **/*.bak
 **/package-lock.json
 **/node_modules/**
+**/dist/**


### PR DESCRIPTION
Currently, only [ts-hello](https://github.com/Moddable-OpenSource/moddable/tree/public/examples/packages/ts-hello) is applicable, but I have added the `dist` directory to `.gitignore`.