### PR TITLE
Add escaping for private scoped modules when building TypeScript on non-windows hosts

### DIFF
--- a/tools/mcmanifest.js
+++ b/tools/mcmanifest.js
@@ -645,7 +645,7 @@ otadata, data, ota, , ${OTADATA_SIZE},`;
 			if (tool.windows)
 				this.line("TSCONFIG:");
 			else
-				this.line(temporaries.join(" "), " : ", "%", tool.slash, "tsconfig.json ", generatedTS.join(" "));
+				this.line(temporaries.join(" ").replaceAll("#", tool.escapedHash), " : ", "%", tool.slash, "tsconfig.json ", generatedTS.join(" "));
 			this.echo(tool, "tsc ", "tsconfig.json");
 			this.line("\t", tool.typescript.compiler, " -p $(MODULES_DIR)", tool.slash, "tsconfig.json");
 			this.line("");


### PR DESCRIPTION
Fix for private-scoped modules where the `#` symbol wasn't being escaped correctly (the tsconfig dependency rule, on non-Windows platforms).   