### PR TITLE
getCharacteristics of web-bluetooth can find all characteristics

### DIFF
--- a/modules/io/ble/web-bluetooth/web-bluetooth.js
+++ b/modules/io/ble/web-bluetooth/web-bluetooth.js
@@ -314,9 +314,14 @@ class BluetoothDevice {
 			return target.promise;
 		}
 		getCharacteristics(ids) {
-			ids = ids.map(id => BluetoothUUID.getCharacteristic(id));
+			if (!ids || ids.length === 0) {
+				ids = undefined;
+			} else {
+				ids = ids.map(id => BluetoothUUID.getCharacteristic(id));
+			}
+
 			const target = Promise.withResolvers();
-			this.device.getCharacteristics(this.#bleService, ids, (error, results) => {
+			this.device.#bleClient.getCharacteristics(this.#bleService, ids, (error, results) => {
 				if (!error && !results.length)
 					error = new Error("not found");
 

--- a/modules/io/ble/web-bluetooth/web-bluetooth.js
+++ b/modules/io/ble/web-bluetooth/web-bluetooth.js
@@ -314,11 +314,7 @@ class BluetoothDevice {
 			return target.promise;
 		}
 		getCharacteristics(ids) {
-			if (!ids || ids.length === 0) {
-				ids = undefined;
-			} else {
-				ids = ids.map(id => BluetoothUUID.getCharacteristic(id));
-			}
+			ids = ids ? ids.map(id => BluetoothUUID.getCharacteristic(id)) : undefined;
 
 			const target = Promise.withResolvers();
 			this.device.#bleClient.getCharacteristics(this.#bleService, ids, (error, results) => {

--- a/modules/io/ble/web-bluetooth/web-bluetooth.js
+++ b/modules/io/ble/web-bluetooth/web-bluetooth.js
@@ -458,7 +458,7 @@ class BluetoothDevice {
 		}
 	
 		get properties() {
-			return new new BluetoothDevice.#BluetoothCharacteristicProperties(this.#bleCharacteristic.properties);
+			return new BluetoothDevice.#BluetoothCharacteristicProperties(this.#bleCharacteristic.properties);
 		}
 		get service() {
 			return this.#service;


### PR DESCRIPTION
I quickly started testing the new Web Bluetooth API, but I found an issue that `getCharacteristics` doesn’t work and I can’t retrieve all the characteristics.

This PR fixes the above issues.