### PR TITLE
Update Timer typings to use Timer IDs

### DIFF
--- a/typings/timer.d.ts
+++ b/typings/timer.d.ts
@@ -19,7 +19,7 @@
 */
 
 declare module "timer" {
-  export type TimerCallback = (timer: Timer) => void;
+  export type TimerCallback = (id: number) => void;
 
   class Timer {
     private constructor()
@@ -27,20 +27,18 @@ declare module "timer" {
       callback: TimerCallback,
       interval?: number,
       repeat?: number
-    ) => Timer
+    ) => number
     static repeat: (
       callback: TimerCallback,
       interval: number,
-    ) => Timer
+    ) => number
     static schedule: (
-      timer: Timer,
+      id: number,
       interval?: number,
       repeat?: number
     ) => void;
-    static clear: (timer: Timer | undefined | null) => void;
+    static clear: (id: number | undefined | null) => void;
     static delay: (milliseconds: number) => void;
-
-    private brand: boolean;
   }
 
   export {Timer as default};


### PR DESCRIPTION
Refactored the `Timer` type definitions to use numeric timer IDs instead of Timer instances. 
Although not included in this repository, I think it is also necessary to modify the following functions defined in `mcpack.d.ts` of  `@moddable/typings`   so that their return values are IDs.

```
declare function setInterval(handler: Function, timeout?: number): void;
declare function setTimeout(handler: Function, timeout?: number): void;
```


