### PR TITLE
Fix typo in documentations

### DIFF
--- a/contributed/httpbridge/README.md
+++ b/contributed/httpbridge/README.md
@@ -29,5 +29,5 @@ or
 
 open browser `http://localhost:8080`
 
-Edit any ts or css file, and on save the browser will auto-update with changes, and the `websocket` is connected to the simulator Modable server
+Edit any ts or css file, and on save the browser will auto-update with changes, and the `websocket` is connected to the simulator Moddable server
 

--- a/contributed/serial/SerialModule.md
+++ b/contributed/serial/SerialModule.md
@@ -162,4 +162,4 @@ Call `serial.poll` with no dictionary to stop polling.
 
 `drivers/sim7100/examples/sim7100gps` demonstrates setting up the SIM7100 GPS and asynchronously receiving GPS updates.
 
-`drivers/sim7100/examples/sim7100sms` demonsrates setting up the SIM7100 to send a SMS message.
+`drivers/sim7100/examples/sim7100sms` demonstrates setting up the SIM7100 to send a SMS message.

--- a/documentation/commodetto/Creating fonts for Moddable applications.md
+++ b/documentation/commodetto/Creating fonts for Moddable applications.md
@@ -35,7 +35,7 @@ Export .png glyph and .fnt font metrics files in the BMFont Binary format.
 <a id="fontbm"></a>
 ## fontbm instructions
 
-To use fontbm, you must first install it on your system. Precompiled binaries are avaiable as part of the Moddable SDK [releases](https://github.com/moddable-OpenSource/moddable/releases/latest) on GitHub. Alternatively, instructions to build it yourself are provided for [macOS](https://github.com/vladimirgamalyan/fontbm#building-macos), [Linux](https://github.com/vladimirgamalyan/fontbm#building-linux), and [Windows](https://github.com/vladimirgamalyan/fontbm?tab=readme-ov-file#building-windows). If you are using xs-dev to manage your Moddable SDK installation, it automatically installs fontbm from the Moddable SDK binaries.
+To use fontbm, you must first install it on your system. Precompiled binaries are available as part of the Moddable SDK [releases](https://github.com/moddable-OpenSource/moddable/releases/latest) on GitHub. Alternatively, instructions to build it yourself are provided for [macOS](https://github.com/vladimirgamalyan/fontbm#building-macos), [Linux](https://github.com/vladimirgamalyan/fontbm#building-linux), and [Windows](https://github.com/vladimirgamalyan/fontbm?tab=readme-ov-file#building-windows). If you are using xs-dev to manage your Moddable SDK installation, it automatically installs fontbm from the Moddable SDK binaries.
 
 Once you have fontbm, you may use it from the command line to generate the .fnt and .png files needed to add fonts to the Moddable SDK.
 
@@ -127,7 +127,7 @@ The `characters` property is a string that indicates which characters to include
 ```
 
 ##### Character List Files
-The `characterFiles` property is an array of paths to UTF-8 encoded text files. All of the characters used in the file are included. 
+The `characterFiles` property is an array of paths to UTF-8 encoded text files. All of the characters used in the file are included.
 
 ```json
 "resources": {

--- a/documentation/commodetto/outline/Outlines.md
+++ b/documentation/commodetto/outline/Outlines.md
@@ -14,7 +14,7 @@ There are three steps to rendering an 2D vector graphics. This document explains
 
 Familiar programming interfaces are supported to define the shapes:
 
-- Canvas paths to build shapes programatically.
+- Canvas paths to build shapes programmatically.
 - SVG paths to use shapes built with vector graphics tools.
 
 The rendering implementation is based on FreeType [Outline Processing](https://freetype.org/freetype2/docs/reference/ft2-outline_processing.html) API.

--- a/documentation/crypt/crypt.md
+++ b/documentation/crypt/crypt.md
@@ -105,7 +105,7 @@ This function is similar to the following `openssl` command line:
 openssl x509 -inform pem -in data.pem -out data.der -outform der
 ```
 
-`pemToDER` looks for both `-----BEGIN CERTIFICATE-----` and `-----BEGIN RSA PRIVATE KEY-----` as delimeters.
+`pemToDER` looks for both `-----BEGIN CERTIFICATE-----` and `-----BEGIN RSA PRIVATE KEY-----` as delimiters.
 
 <a id="transform-privateKeyToPrivateKeyInfo"></a>
 ### static privateKeyToPrivateKeyInfo(data[, oid])

--- a/documentation/devices/gecko/GeckoBuild.md
+++ b/documentation/devices/gecko/GeckoBuild.md
@@ -357,7 +357,7 @@ At wakeup, an application can check for the cause of wakeup and perform actions 
 
 `wakeup`:`register` specifies which GPIO interrupt register to use.
 
-The various Gecko devices specify port/pin combinations that will wake the device from EM4 sleep. The device's data sheet will specify what pins can be used, and what GPIO interupt register to use.
+The various Gecko devices specify port/pin combinations that will wake the device from EM4 sleep. The device's data sheet will specify what pins can be used, and what GPIO interrupt register to use.
 
 
 ### class Sleep

--- a/documentation/devices/moddable-six.md
+++ b/documentation/devices/moddable-six.md
@@ -54,7 +54,7 @@ The ESP32-S3 module has an expansive 8 MB of flash storage memory and 8 MB PSRAM
 #### Beautiful, Fast, and Responsive screen
 The screen is 240 x 320 QVGA IPS display driven by a 8-bit wide parallel data bus. Display throughput is at least 4x faster than anything we've had before, thanks to a new hardware design and a new parallel display driver.
 
-The brightness of the display can be adjusted programatically.
+The brightness of the display can be adjusted programmatically.
 
 #### Responsive Multi-Touch
 The touch panel uses a GT911 touch controller that supports multi-touch input. The a new touch driver and hardware design enables touch interrupts to increase responsiveness and minimize CPU overhead.

--- a/documentation/devices/nRF52-low-power.md
+++ b/documentation/devices/nRF52-low-power.md
@@ -21,7 +21,7 @@ Warning: These notes are preliminary. Omissions and errors are likely. If you en
 
 <a id="low-power-modes"></a>
 ## Low Power Modes
-The Nordic nRF52 devices (Moddable Four) provide two low power (sleep) modes to reduce power consumption: **System ON** and **System OFF**. Applications can programatically enter and exit these power modes using Nordic APIs. The [nRF52840 Product Specification](https://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.0.pdf), Section 5.2 includes current consumption tables for common scenarios.
+The Nordic nRF52 devices (Moddable Four) provide two low power (sleep) modes to reduce power consumption: **System ON** and **System OFF**. Applications can programmatically enter and exit these power modes using Nordic APIs. The [nRF52840 Product Specification](https://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.0.pdf), Section 5.2 includes current consumption tables for common scenarios.
 
 The Moddable SDK includes APIs to configure and leverage features provided by these low power modes.
 

--- a/documentation/devices/pico.md
+++ b/documentation/devices/pico.md
@@ -76,8 +76,8 @@ The Moddable SDK supports devices built with the Pico. The following table lists
 
 | Name | Platform identifier | Key features | Links |
 | :---: | :--- | :--- | :--- |
-| <img src="../assets/devices/pi-pico.png" width=220><BR>Rasberry Pi<BR>Pico | `pico` | LED, 26 external pins  | <li>[Raspberry Pi Pico documentation](https://www.raspberrypi.org/documentation/pico/getting-started/)</li> |
-| <img src="../assets/devices/pi-pico_w.png" width=65><BR>Rasberry Pi<BR>Pico W | `pico/pico_w` | Wi-Fi, LED, 26 external pins  | <li>[Raspberry Pi Pico documentation](https://www.raspberrypi.org/documentation/pico/getting-started/)</li> |
+| <img src="../assets/devices/pi-pico.png" width=220><BR>Raspberry Pi<BR>Pico | `pico` | LED, 26 external pins  | <li>[Raspberry Pi Pico documentation](https://www.raspberrypi.org/documentation/pico/getting-started/)</li> |
+| <img src="../assets/devices/pi-pico_w.png" width=65><BR>Raspberry Pi<BR>Pico W | `pico/pico_w` | Wi-Fi, LED, 26 external pins  | <li>[Raspberry Pi Pico documentation](https://www.raspberrypi.org/documentation/pico/getting-started/)</li> |
 | <img src="../assets/devices/pico-display.png" width=80></a><BR>Pimoroni<BR>Pico Display | `pico/pico_display`<BR>`simulator/pico_display` | **1.4" IPS display**<BR>135 x 240<BR>16-bit color<BR>4 buttons<BR>RGB LED | <li>[Pimoroni Pico Display](https://pimoroni.com/picodisplay)</li> |
 | <img src="../assets/devices/pico-display-2.png" width=200></a><BR>Pimoroni<BR>Pico Display 2 | `pico/pico_display_2`<BR>`simulator/pico_display_2` | **2.0" IPS display**<BR>320 x 240<BR>16-bit color<BR>4 buttons<BR>RGB LED | <li>[Pimoroni Pico Display 2](https://shop.pimoroni.com/products/pico-display-pack-2-0)</li> |
 | <img src="../assets/devices/pico-lcd-1.3.png" width=220></a><BR>Waveshare<BR>Pico LCD 1.3 | `pico/pico_lcd_1.3` | **1.3" IPS display**<BR>240 x 240<BR>16-bit color<BR>4 buttons<BR>1 joystick | <li>[Waveshare Pico LCD 1.3](https://www.waveshare.com/wiki/Pico-LCD-1.3)</li> |
@@ -107,7 +107,7 @@ The Raspberry Pi Pico 2 has the following features:
 
 | Name | Platform identifier | Key features | Links |
 | :---: | :--- | :--- | :--- |
-| <img src="../assets/devices/pi-pico_2.png" width=220><BR>Rasberry Pi<BR>Pico 2 | `pico` | LED, 26 external pins  | <li>[Raspberry Pi Pico documentation](https://www.raspberrypi.org/documentation/pico/getting-started/)</li> |
+| <img src="../assets/devices/pi-pico_2.png" width=220><BR>Raspberry Pi<BR>Pico 2 | `pico` | LED, 26 external pins  | <li>[Raspberry Pi Pico documentation](https://www.raspberrypi.org/documentation/pico/getting-started/)</li> |
 | <img src="../assets/devices/pico-sparkfun-pro-micro-rp2040.png" width=220></a><br>Sparkfun<br>Pro Micro RP2040 | `pico/pro_micro` | Qwiic/STEMMA connector, Neopixel | <li>[Sparkfun product page](https://www.sparkfun.com/products/18288)</li> |
 | <img src="../assets/devices/pico-pimoroni-pico-plus-2.png" height=220></a><br>Pimoroni<br>pico plus 2 | `pico/pico_plus_2` | Qwiic/STEMMA connector | <li>[Pimoroni product page](https://shop.pimoroni.com/products/pimoroni-pico-plus-2)</li> |
 
@@ -185,7 +185,7 @@ The Raspberry Pi Pico 2 has the following features:
 	cd build
 	cmake ..
 	make
-	
+
 	cd pioasm
 	cmake $PICO_SDK_DIR/tools/pioasm
 	make
@@ -306,7 +306,7 @@ Not yet available.
 	cd build
 	cmake ..
 	make
-	
+
 	cd pioasm
 	cmake $PICO_SDK_DIR/tools/pioasm
 	make

--- a/documentation/displays/wiring-guide-adafruit-1.8-st7735.md
+++ b/documentation/displays/wiring-guide-adafruit-1.8-st7735.md
@@ -14,7 +14,7 @@ Revised: December 10, 2018
 | **Interface** | SPI
 | **Drivers** | video [ST7735](../../documentation/drivers/st7735/st7735.md), no touch
 | **Availability** | [Adafruit 1.8" Color TFT LCD Display](https://www.adafruit.com/product/358)<BR>[HiLetgo 1.8" ST7735R](https://www.amazon.com/gp/product/B00LSG51MM/)
-| **Description** | Colorful, bright display wtih 4-wire SPI.
+| **Description** | Colorful, bright display with 4-wire SPI.
 
 
 ## Moddable example code

--- a/documentation/drivers/neostrand/neostrand.md
+++ b/documentation/drivers/neostrand/neostrand.md
@@ -312,7 +312,7 @@ start | 0 | [0..strand.length] | index of first pixel of effect
 end | strand.length | [0..strand.length] | index of last pixel of effect
 duration | 1000 | | length time between color changes, in ms
 size | 5 | [0..strand.length] | size of each color
-max | 127 | [0..255] | maximium value of random RGB component
+max | 127 | [0..255] | maximum value of random RGB component
 
 Using *Pattern* as a starting point, we'll change the class name and constructor, set up the timeline in `activate` and provide a setter for the changing `effectValue`. The `loopPrepare` function will be called before a looping effect starts or restarts.
 

--- a/documentation/network/ble/ble.md
+++ b/documentation/network/ble/ble.md
@@ -1745,7 +1745,7 @@ onDisconnected() {
 	this.stopMeasurements();
 	this.startAdvertising({
 		filterPolicy: GAP.AdvFilterPolicy.WHITELIST_SCANS_CONNECTIONS,
-		advertisingData: {flags: 6, completeName: this.deviceName, completeUUID16List: [HEART_RATE_SERVIE_UUID, BATTERY_SERVICE_UUID]
+		advertisingData: {flags: 6, completeName: this.deviceName, completeUUID16List: [HEART_RATE_SERVICE_UUID, BATTERY_SERVICE_UUID]
 	});
 }
 ```

--- a/documentation/network/network.md
+++ b/documentation/network/network.md
@@ -1,6 +1,6 @@
 # Networking
 Copyright 2017-2024 Moddable Tech, Inc.<BR>
-Revised: Febrary 23, 2024
+Revised: February 23, 2024
 
 ## Table of Contents
 
@@ -378,7 +378,7 @@ request.close();
 
 The `read` function behaves exactly like the read function of the `Socket` class. The `read` function can only be called inside the callback providing a response body fragment.
 
-> **Note**: The HTTP read function implentation does not currently support passing a `String` for the `until` argument on a response that uses chunked transfer-encoding.
+> **Note**: The HTTP read function implementation does not currently support passing a `String` for the `until` argument on a response that uses chunked transfer-encoding.
 
 ***
 
@@ -462,7 +462,7 @@ The user of the server receives status information through the callback function
 | 1 | `connection` | New connection received. A new requested has been accepted by the server.
 | 2 | `status` | Status line of request received. The `val1` argument contains the request path (e.g. `index.html`) and `val2` contains the request method (e.g. `GET`).
 | 3 | `header` | One header received. A single HTTP header has been received, with the header name in lowercase letters in `val1` (e.g. `connection`) and the header value (e.g. `close`) in `val2`.
-| 4 | `headersComplete` | All headers received. All HTTP headers have been received. Return `String` or `ArrayBuffer` to receive the complete request body as an argument to the `requestComplete` message as the corresponding type; return `true` to have `requestFragment` invoked as the fragments arrive. Return `false` or `undefined` to ignore the request body. The behavior for ohter return values is undefined.
+| 4 | `headersComplete` | All headers received. All HTTP headers have been received. Return `String` or `ArrayBuffer` to receive the complete request body as an argument to the `requestComplete` message as the corresponding type; return `true` to have `requestFragment` invoked as the fragments arrive. Return `false` or `undefined` to ignore the request body. The behavior for other return values is undefined.
 | 5 | `requestFragment` |
 | 6 | `requestComplete` |
 | 8 | `prepareResponse` | Prepare response. The server is ready to send the response. Callback returns a dictionary with the response status (e.g. 200) in the `status` property, HTTP headers in an array on the `headers` property, and the response body on the `body` property. If the status property is missing, the default value of `200` is used. If the body is a `String` or `ArrayBuffer`, it is the complete response. The server adds the `Content-Length` HTTP header. If the body property is set to `true`, the response is delivered using the `Transfer-encoding` mode `chunked`, and the callback is invoked to retrieve each response fragment.

--- a/documentation/pins/audioout.md
+++ b/documentation/pins/audioout.md
@@ -179,7 +179,7 @@ A subset of the samples in the buffer may be selected for playback by using the 
 
 #### Enqueuing tones and silence
 
-To `enqueue` a tone, provide the frequency and number of samples. The square wave will be generated.  The following queues 8000 samples of a 440 Hz A natural. Pass `Infinty` for the sample count to play the tone until `flush`,  `stop`, or `close`.
+To `enqueue` a tone, provide the frequency and number of samples. The square wave will be generated.  The following queues 8000 samples of a 440 Hz A natural. Pass `Infinity` for the sample count to play the tone until `flush`,  `stop`, or `close`.
 
 ```js
 audio.enqueue(0, AudioOut.Tone, 440, 8000);

--- a/documentation/pins/pins.md
+++ b/documentation/pins/pins.md
@@ -417,7 +417,7 @@ The constructor dictionary has an optional `hz` property to specify the speed of
 let sensor = new I2C({sda: 5, scl: 4, address: 0x48, hz: 1000000});
 ```
 
-The constructor dictionary also has an optional `timeout` property to specify the I2C clock stretching timeout in microseonds (μs). Support for this property is device dependent.
+The constructor dictionary also has an optional `timeout` property to specify the I2C clock stretching timeout in microseconds (μs). Support for this property is device dependent.
 
 ```js
 let sensor = new I2C({sda: 5, scl: 4, address: 0x48, timeout: 600});

--- a/documentation/piu/ae motion export.md
+++ b/documentation/piu/ae motion export.md
@@ -8,7 +8,7 @@ Adobe After Effects can be used to export motion data into a Moddable sample app
 
 Moddable motion control only supports position.
 
-In AE only layers with assets are exported and only positions are exported. Scaling, rotation, transparncy, etc. are not exported.
+In AE only layers with assets are exported and only positions are exported. Scaling, rotation, transparency, etc. are not exported.
 
 Piu interpolates linearly between values in the array. You can reduce the frame rate in After Effects to reduce the size of the arrays. Piu will animate between values based on defined time length of the motion effect.
 

--- a/documentation/piu/piu.md
+++ b/documentation/piu/piu.md
@@ -341,7 +341,7 @@ trace(`sampleVariable value is: ${sampleVariable}\n`);    // "sampleVariable val
 
 ### Adding Additional Properties
 
-Additional properites can be added by setting a property of the global object.
+Additional properties can be added by setting a property of the global object.
 
 ```javascript
 global.application = new Application(null, {
@@ -699,7 +699,7 @@ The `states` and `variants` properties of `texture` objects should not be confus
 
 The `state` and `variant` of a `content` can be updated at any time. This is often done when an event is triggered.
 
-```javscript
+```javascript
 let WiFiStatusIcon = Content.template($ => ({
     skin: wiFiSkin, state: $.passwordProtected, variant: 0,
     interval: 500, duration: 2500, loop: true,
@@ -4052,7 +4052,7 @@ let timeline = new Timeline();
 | Argument | Type | Description |
 | --- | --- | :--- |
 | `target` | `object` | The object that will have its properties tweened by the timeline.
-| `fromProperties` | `object` | The keys of this object are the properties of the `target` object that will be tweened by the timeline. Their values are the starting values the properties of the `target` object will have at the begining of the tween.
+| `fromProperties` | `object` | The keys of this object are the properties of the `target` object that will be tweened by the timeline. Their values are the starting values the properties of the `target` object will have at the beginning of the tween.
 | `duration` | `number` | The duration of the tween in ms.
 | `easing` | `number` | An easing function to use for the tween. If `null` is provided, the tween will use a linear easing function.
 | `delay` | `number` | The number of ms after the previous tween in the timeline completes that this one should begin. If this number is negative, the tween will begin before the prior tween completes. If no duration is provided, the tween will begin immediately upon completion of the prior tween.

--- a/documentation/tools/testing.md
+++ b/documentation/tools/testing.md
@@ -425,7 +425,7 @@ When writing tests that use the network, the first step is to make sure the micr
 
 ```js
 /*---
-flags: [module,aync]
+flags: [module,async]
 ---*/
 import {Client} from "http";
 await $NETWORK.connected;

--- a/documentation/tools/tools.md
+++ b/documentation/tools/tools.md
@@ -103,7 +103,7 @@ mcconfig [manifest] [-d] [-f format] [-i] [-m] [-o directory] [-p platform] [-r 
 
 When the `-t` flag is omitted, the default value is `all`.
 
-When using **mcconfig** with microcontrollers that use a serial port for JavaScript debuggging with xsbug, the `deploy`, `xsbug`, and `all` targets terminate the currently running instance of serial2xsbug, if there is one.
+When using **mcconfig** with microcontrollers that use a serial port for JavaScript debugging with xsbug, the `deploy`, `xsbug`, and `all` targets terminate the currently running instance of serial2xsbug, if there is one.
 
 <a id="mcrun"></a>
 ## mcrun
@@ -112,7 +112,7 @@ When using **mcconfig** with microcontrollers that use a serial port for JavaScr
 There are a few important differences between `mcrun` and `mcconfig`:
 
 - The manifest used by `mcrun` must not reference any files which build to native code (e.g. `.c` or `.cpp` files) as a mod can only contain JavaScript
-- `mcrun` supports `-t build`` (but not other [target values](#buildtargets)). 
+- `mcrun` supports `-t build`` (but not other [target values](#buildtargets)).
 - `config` properties are available from the `mod/config` module instead of `mc/config` (see the `config` section of the [Manifest](./manifest.md) documentation for more information about `config` properties)
 
 ### Arguments

--- a/documentation/xs/XS Compartment.md
+++ b/documentation/xs/XS Compartment.md
@@ -226,7 +226,7 @@ If the `specifier` property is present, its value is coerced into a string and b
 	- If the `compartment` property is present, its value must be a compartment.
 	- If absent, the `compartment` property defaults to the compartment being constructed in the `modules` option, or being hooked in the `loadHook` and `loadNowHook` options.
 
-- Else if the value of the `namespace ` property is a module namepace, the descriptor shares a module that is already available.
+- Else if the value of the `namespace ` property is a module namespace, the descriptor shares a module that is already available.
 
 - Else the value of `record` property must be an object. The module is loaded and initialized from the object according to the [virtual module namespace](#VirtualModuleNamespace) pattern.
 

--- a/documentation/xs/XS Platforms.md
+++ b/documentation/xs/XS Platforms.md
@@ -77,7 +77,7 @@ For instance, on Mac, the `mxMachinePlatform` macro adds references to a socket 
 ```c
 #include <CoreServices/CoreServices.h>
 
-#define mxMachinePlatfom \
+#define mxMachinePlatform \
 	CFSocketRef connection; \
 	CFRunLoopSourceRef connectionSource; \
 	CFRunLoopSourceRef promiseSource;
@@ -88,7 +88,7 @@ On Windows, the `mxMachinePlatform` macro adds the socket and message window han
 ```c
 #include <winsock2.h>
 
-#define mxMachinePlatfom \
+#define mxMachinePlatform \
 	SOCKET connection; \
 	HWND window;
 ```
@@ -117,7 +117,7 @@ The functions are grouped into meaningful sections. The xsPlatform.c file can al
 
 ### Debug
 
-The functions in this section are only necessary for the debug version of XS. They can be condtionally defined within:
+The functions in this section are only necessary for the debug version of XS. They can be conditionally defined within:
 
 ```c
 #ifdef mxDebug
@@ -535,7 +535,7 @@ From XS point of view, `SharedArrayBuffer` instances are host objects, i.e. inst
 
 What is a shared chunk is defined by the platform. XS atomically accesses 8-bit, 16-bit or 32-bit signed or unsigned integers inside the data of a shared chunk. XS accesses integers either thru GCC atomics, or between calls to `fxLockSharedChunk` and `fxUnlockSharedChunk`
 
-Since `Atomics.wait` and `Atomics.wake` require to synchonize the **shared cluster** of machines created or cloned by XS, platforms usually need a global synchronization mechanism, and synchronization related fields in every machine record, thru the `mxMachinePlatform` macro explained here above.
+Since `Atomics.wait` and `Atomics.wake` require to synchronize the **shared cluster** of machines created or cloned by XS, platforms usually need a global synchronization mechanism, and synchronization related fields in every machine record, thru the `mxMachinePlatform` macro explained here above.
 
 #### Shared Cluster
 

--- a/documentation/xs/XS in C.md
+++ b/documentation/xs/XS in C.md
@@ -672,13 +672,13 @@ if (xsIsInstanceOf(xsThis, xsObjectPrototype))
 
 In ECMAScript, the properties of an object are identified by number, string or symbol values – a.k.a. the property **key**. In XS in C you can access properties with property keys through the `xsGetAt`, `xsSetAt`, etc macros described below.
 
-If the number or string value of a property key can be converted into a 32-bit unsigned integer, XS uses the result of the conversion – a.k.a. the property **index** — to identify the property. In XS in C, you can access properties directy with property indexes through the `xsGetIndex`, `xsSetIndex`, etc macros described below. A property index can be used with all instances but is typically used to access items of `Array` instances.
+If the number or string value of a property key can be converted into a 32-bit unsigned integer, XS uses the result of the conversion – a.k.a. the property **index** — to identify the property. In XS in C, you can access properties directly with property indexes through the `xsGetIndex`, `xsSetIndex`, etc macros described below. A property index can be used with all instances but is typically used to access items of `Array` instances.
 
 ```c
 typedef uint32_t xsIndex;
 ```
 
-Otherwise the string or symbol value of a property key is stored into a table and XS uses the resulting table index – a.k.a. the property **identifier** — to identify the property. In XS in C, you can access properties directy with property identifiers through the `xsGet`, `xsSet` etc macros described below.
+Otherwise the string or symbol value of a property key is stored into a table and XS uses the resulting table index – a.k.a. the property **identifier** — to identify the property. In XS in C, you can access properties directly with property identifiers through the `xsGet`, `xsSet` etc macros described below.
 
 ```c
 typedef uint16_t xsIdentifier;
@@ -1002,7 +1002,7 @@ if (xsHasIndex(xsThis, 7));
 
 #### xsGet
 
-To get a property of an instance by identifer, use the `xsGet` macro.
+To get a property of an instance by identifier, use the `xsGet` macro.
 
 **`xsSlot xsGet(xsSlot theThis, xsIdentifier theID)`**
 
@@ -1996,7 +1996,7 @@ Regarding the parameters of the machine that are specified in the `xsCreation` s
 
 - Some XS hosts attempt to grow the slot and chunk heaps without limit at runtime to accommodate the memory needs of the hosted scripts; others limit the maximum memory that may be allocated to the machine. For the latter, the `staticSize` defines the total number of bytes that may be allocated for the combination of chunks and slots, which includes the stack. In general, only hosts running on resource constrained devices implement `staticSize`.
 
-- When creating the machine also allocates a task,  `nativeStackSize` indicates the mimimum size in bytes for the native stack. 
+- When creating the machine also allocates a task,  `nativeStackSize` indicates the minimum size in bytes for the native stack.
 
 ***
 
@@ -2101,7 +2101,7 @@ A host object is an XS object that has a data pointer that can only be accessed 
 
 Host data is a pointer stored by XS in a host object. The pointer and data it points to are managed entirely by the host object's C code. XS stores the pointer but does not access it in any way. Host data is usually allocated with `malloc`/`calloc`, but this isn't required. Host data is disposed by the host object's destructor.
 
-A host chunk is memory allocated by XS in its chunk heap for use by a host object from its native C code. XS garbage collects this storage when the host object is garbage collected. The memory is relocatable (like all XS chunks), so unlike Host Data it avoids losing memory to fragmentation. However, it requires some extra attention because the pointer may be invalidated when the garbage collector compacts memory. Therefore, C code needs to refetch the pointer after any operation which might trigger a garbage collection. Because the chunk pointer can move, it can only be used inside an XS callback; accessing it from an interrupt, for example, is unsafe because it could be moving. The [Rectangle example](#rectangle-example) shows how to use a host chunk. 
+A host chunk is memory allocated by XS in its chunk heap for use by a host object from its native C code. XS garbage collects this storage when the host object is garbage collected. The memory is relocatable (like all XS chunks), so unlike Host Data it avoids losing memory to fragmentation. However, it requires some extra attention because the pointer may be invalidated when the garbage collector compacts memory. Therefore, C code needs to refetch the pointer after any operation which might trigger a garbage collection. Because the chunk pointer can move, it can only be used inside an XS callback; accessing it from an interrupt, for example, is unsafe because it could be moving. The [Rectangle example](#rectangle-example) shows how to use a host chunk.
 
 Implementing a host object using host data is easier than a host chunk, but potentially less memory efficient.
 

--- a/documentation/xs/mods.md
+++ b/documentation/xs/mods.md
@@ -427,7 +427,7 @@ When loading the archive, XS iterates on the symbol table to build a mapped iden
 
 The atom structuring mechanism is a lightweight way of structuring binary data.
 
-Each atom begins with an 8 byte header consisting of two 32-bit big-endian values. The first value is an unsigned integer that indicates the size of the atom, including the header, in bytes.  The second value is a [four-character code](https://en.wikipedia.org/wiki/FourCC), typically consisting of human-readable ASCII values, that indentifies the content of the atom. For example, for the sole atom at the root of an XS archive file, the first value is the length of the file in bytes and the second value is `XS_A` indicating an atom containing an XS archive.
+Each atom begins with an 8 byte header consisting of two 32-bit big-endian values. The first value is an unsigned integer that indicates the size of the atom, including the header, in bytes.  The second value is a [four-character code](https://en.wikipedia.org/wiki/FourCC), typically consisting of human-readable ASCII values, that identifiers the content of the atom. For example, for the sole atom at the root of an XS archive file, the first value is the length of the file in bytes and the second value is `XS_A` indicating an atom containing an XS archive.
 
 Each atom may contain atoms and/or other data. The content of an atom is defined by its four-character code. For example, the `RSRC` atom above is defined to contain zero or more pairs of `PATH` and `DATA` atoms, whereas the `NAME` atom is defined to contain a null terminated string.
 

--- a/documentation/xs/preload.md
+++ b/documentation/xs/preload.md
@@ -265,7 +265,7 @@ These objects cannot be stored in flash. However, they maybe used during preload
 
 It is possible to modify the behavior of built-in objects before they are frozen by using a preloaded module since built-in objects are not frozen until preload is complete.  This allows for the extension of built-in object behavior.
 
-For example, the `Error.protoype.name` property is an ordinary property (as specified by [ECMA-262](https://tc39.es/ecma262/#sec-error.prototype.name)), which when frozen will result in throwing an error when attempting to write to `name`:
+For example, the `Error.prototype.name` property is an ordinary property (as specified by [ECMA-262](https://tc39.es/ecma262/#sec-error.prototype.name)), which when frozen will result in throwing an error when attempting to write to `name`:
 
 
 ```js

--- a/examples/io/analog/README.md
+++ b/examples/io/analog/README.md
@@ -30,7 +30,7 @@ Vref is a reference voltage used internally by ESP32 ADCs for measuring the inpu
 
 There are [four attenuation](https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/api-reference/peripherals/adc.html#adc-attenuation) options.
 
-| Attenuation (dB) | Measureable input voltage range |
+| Attenuation (dB) | Measurable input voltage range |
 | :---: | :--- |
 | 0 | 100 mV ~ 950 mV
 | 2.5 | 100 mV ~ 1250 mV


### PR DESCRIPTION
I had no trouble reading documents, but I found several typos, so I’ll correct them. I found these typos using [cspell](https://www.npmjs.com/package/cspell).
