### PR TITLE
Add MCP23017 expander module to manifest

### DIFF
--- a/examples/io/i2c/expander/main.js
+++ b/examples/io/i2c/expander/main.js
@@ -12,7 +12,7 @@
  *
  */
 
-import Expander from "embedded:io/provider/MCP23017";
+import Expander from "embedded:io/provider/MCP23X17";
 
 const expander = new Expander({
 	i2c: device.I2C.default,

--- a/examples/io/i2c/expander/manifest.json
+++ b/examples/io/i2c/expander/manifest.json
@@ -1,13 +1,10 @@
 {
 	"include": [
 		"$(MODDABLE)/examples/manifest_base.json",
-		"$(MODDABLE)/modules/io/manifest.json"
+		"$(MODDABLE)/modules/io/manifest.json",
+		"$(MODDABLE)/modules/io/expander/manifest.json"
 	],
 	"modules": {
-		"*": "./main",
-		"embedded:io/provider/MCP23017": "$(MODDABLE)/modules/io/expander/expander"
-	},
-	"preload": [
-		"embedded:io/provider/MCP23017"
-	]
+		"*": "./main"
+	}
 }

--- a/examples/io/i2c/expander/manifest.json
+++ b/examples/io/i2c/expander/manifest.json
@@ -4,6 +4,10 @@
 		"$(MODDABLE)/modules/io/manifest.json"
 	],
 	"modules": {
-		"*": "./main"
-	}
+		"*": "./main",
+		"embedded:io/provider/MCP23017": "$(MODDABLE)/modules/io/expander/expander"
+	},
+	"preload": [
+		"embedded:io/provider/MCP23017"
+	]
 }

--- a/modules/io/expander/manifest.json
+++ b/modules/io/expander/manifest.json
@@ -1,0 +1,8 @@
+{
+	"modules": {
+		"embedded:io/provider/MCP23X17": "./expander"
+	},
+	"preload": [
+		"embedded:io/provider/MCP23X17"
+	]
+}


### PR DESCRIPTION
Updated `manifest.json` to include the MCP23017 expander module and preload it. This allows the example to use the MCP23017 I/O expander functionality.