### PR TITLE
Added FreeRTOS and ESP32 Core settings to worker configuration

### DIFF
--- a/documentation/base/worker.md
+++ b/documentation/base/worker.md
@@ -49,7 +49,7 @@ let aWorker = new Worker("simpleworker", {
 	},
 	nativeStack: 8192,	// host's native "C" stack, in bytes
 	priority: 3,		// For FreeRTOS, sets the Worker Task priority
-	coreId: 1			// For ESP32, set the execution core. 0 or 1
+	core: 1				// For ESP32, set the execution core. 0 or 1
 });
 ```
 For systems using FreeRTOS (ESP32, Qualcomm QCA4020, and Nordic nRF52), there are two additional settings.  `nativeStack` sets the size of the native stack in the FreeRTOS `xTaskCreate` call.  The default `nativeStack` size allocated varies with the processor:
@@ -60,7 +60,7 @@ For systems using FreeRTOS (ESP32, Qualcomm QCA4020, and Nordic nRF52), there ar
 
 `priority`  sets the worker's task priority. The default worker task priority is 1 (`tskIDLE_PRIORITY + 1`), the main Moddable JavaScript task priority is 4, and I/O tasks (serial, SPI, I2C) run at priority 10. Setting the `priority` too high could have a detrimental impact on your project's performance. 
 
-For ESP32 users with multi-core processors, the `coreId` setting allows pinning the worker to a specific CPU core. By default, the ESP32 task scheduler redistributes worker tasks across cores to balance performance, which is usually the optimal setting. ESP32 normally runs Wi-Fi/BLE and system daemons on core 0, so pinning a worker on core 1 may improve real-time performance. `xsbug` displays the cores, and you can visually see each processor's usage.
+For ESP32 users with multi-core processors, the `core` setting allows pinning the worker to a specific CPU core. By default, the ESP32 task scheduler redistributes worker tasks across cores to balance performance, which is usually the optimal setting. ESP32 normally runs Wi-Fi/BLE and system daemons on core 0, so pinning a worker on core 1 may improve real-time performance. `xsbug` displays the cores, and you can visually see each processor's usage.
 
 
 ### Sending a message to a worker

--- a/documentation/base/worker.md
+++ b/documentation/base/worker.md
@@ -34,7 +34,7 @@ To launch a worker, create an instance of the `Worker` class, passing the name o
 let aWorker = new Worker("simpleworker");
 ```
 
-The call to the `Worker` constructor returns only after execution of the specified module completes. If the worker module generates an exception during this step, an exception is propagated so that the call to `new Worker` throws an exception. This behavior means that the invoking virtual machine blocks until the new worker virtual machine has completed initialization. Consequently, any operations performed in a newly instantiated virtual machine should be relatively brief.
+The call to the `Worker` constructor returns only after the execution of the specified module completes. If the worker module generates an exception during this step, an exception is propagated so that the call to `new Worker` throws an exception. This behavior means that the invoking virtual machine blocks until the new worker virtual machine has completed initialization. Consequently, any operations performed in a newly instantiated virtual machine should be relatively brief.
 
 ### Launching a worker with memory configuration
 The previous example launches the worker with the default memory [creation](../tools/manifest.md#creation) configuration used for the main virtual machine. This may not be large enough for the worker, or may allocate more RAM than needed by the worker. An optional configuration object allows the script instantiating a new virtual machine to set the memory use.
@@ -48,16 +48,19 @@ let aWorker = new Worker("simpleworker", {
 		incremental: 32
 	},
 	nativeStack: 8192,	// host's native "C" stack, in bytes
-    coreId: 1			// For ESP32, set the execution core. 0 or 1
+	priority: 3,		// For FreeRTOS, sets the Worker Task priority
+	coreId: 1			// For ESP32, set the execution core. 0 or 1
 });
 ```
-There are two optional settings for Workers. For systems using FreeRTOS (ESP32, Qualcomm QCA4020, and Nordic nRF52),  nativeStack sets the size of the native stack in the FreeRTOS `xTaskCreate` call.  The default `nativeStack` size allocated varies with the processor:
+For systems using FreeRTOS (ESP32, Qualcomm QCA4020, and Nordic nRF52), there are two additional settings.  `nativeStack` sets the size of the native stack in the FreeRTOS `xTaskCreate` call.  The default `nativeStack` size allocated varies with the processor:
 
 - Espressif ESP32: 5 KB with logging disabled; 6 KB with logging enabled
 - Qualcomm QCA4020: 9 KB
-- Nordic nFS52: 10 KB
+- Nordic nRF52: 10 KB
 
-For ESP32 users with multi-core processors, the `coreId` setting allows pinning the worker to a specific CPU core. By default, the ESP32 task scheduler redistributes worker tasks across cores to balance performance, which is usually the optimal setting. ESP32 normally runs Wi-Fi/BLE and system daemons on core 0, so pinning a worker on core 1 may improve real-time performance. `xsbug` displays the cores and you can visually see each processor's usage.
+`priority`  sets the worker's task priority. The default worker task priority is 1 (`tskIDLE_PRIORITY + 1`), the main Moddable JavaScript task priority is 4, and I/O tasks (serial, SPI, I2C) run at priority 10. Setting the `priority` too high could have a detrimental impact on your project's performance. 
+
+For ESP32 users with multi-core processors, the `coreId` setting allows pinning the worker to a specific CPU core. By default, the ESP32 task scheduler redistributes worker tasks across cores to balance performance, which is usually the optimal setting. ESP32 normally runs Wi-Fi/BLE and system daemons on core 0, so pinning a worker on core 1 may improve real-time performance. `xsbug` displays the cores, and you can visually see each processor's usage.
 
 
 ### Sending a message to a worker
@@ -209,7 +212,7 @@ Depending on the host runtime, workers may be preemptively scheduled (e.g. run i
 
 The Web Worker specification requires assumes that all Workers are preemptively scheduled. On some microcontrollers, preemptive scheduling is impractical (too much memory required) or nearly impossible (not supported by the host RTOS).
 
-Each host of the Moddable SDK runtime decided whether to support multiple virtual machines. If it does, it then decides whether to support preemptive or cooperative scheduling.  The ESP8266 runtime is built on a cooperative task model and so implements cooperative scheduling of virtual machines. The ESP32, Qualcomm QCA4020, and Nordic nRF52 runtimes are built on FreeRTOS, a preemptively scheduled RTOS, and so support preemptive scheduling. For FreeRTOS, workers run at priority 1 (0 is the lowest level priority). When deciding whether to use multiple virtual machines in a project, check to see what is supported by the host runtime.
+Each host of the Moddable SDK runtime decided whether to support multiple virtual machines. If it does, it then decides whether to support preemptive or cooperative scheduling.  The ESP8266 runtime is built on a cooperative task model and so implements cooperative scheduling of virtual machines. The ESP32, Qualcomm QCA4020, and Nordic nRF52 runtimes are built on FreeRTOS, a preemptively scheduled RTOS, and so support preemptive scheduling. For FreeRTOS, workers run at priority 1 (where 0 is the lowest level of priority). When deciding whether to use multiple virtual machines in a project, check to see what is supported by the host runtime.
 
 ## xsbug support
 The debugger for the XS virtual machine, `xsbug`, supports working with multiple virtual machines simultaneously. Each virtual machine appears in a separate tab with the name of the module path used to initialize the worker.

--- a/documentation/base/worker.md
+++ b/documentation/base/worker.md
@@ -37,19 +37,28 @@ let aWorker = new Worker("simpleworker");
 The call to the `Worker` constructor returns only after execution of the specified module completes. If the worker module generates an exception during this step, an exception is propagated so that the call to `new Worker` throws an exception. This behavior means that the invoking virtual machine blocks until the new worker virtual machine has completed initialization. Consequently, any operations performed in a newly instantiated virtual machine should be relatively brief.
 
 ### Launching a worker with memory configuration
-The previous example launches the worker with the default memory creation configuration used for the main virtual machine. This may not be large enough for the worker, or may allocate more RAM than needed by the worker. An optional configuration object allows the script instantiating a new virtual machine to set the memory use.
+The previous example launches the worker with the default memory [creation](../tools/manifest.md#creation) configuration used for the main virtual machine. This may not be large enough for the worker, or may allocate more RAM than needed by the worker. An optional configuration object allows the script instantiating a new virtual machine to set the memory use.
 
 ```js
 let aWorker = new Worker("simpleworker", {
-	static: 8192,
-	stack: 64,			// JavaScript stack
-	heap: {
+	static: 8192,		// bytes
+	stack: 64,			// JavaScript stack in 16 byte slots
+	heap: {				// Values in 16 byte slots
 		initial: 64,
 		incremental: 32
 	},
-	nativeStack: 8192	// host's native "C" stack
+	nativeStack: 8192,	// host's native "C" stack, in bytes
+    coreId: 1			// For ESP32, set the execution core. 0 or 1
 });
 ```
+There are two optional settings for Workers. For systems using FreeRTOS (ESP32, Qualcomm QCA4020, and Nordic nRF52),  nativeStack sets the size of the native stack in the FreeRTOS `xTaskCreate` call.  The default `nativeStack` size allocated varies with the processor:
+
+- Espressif ESP32: 5 KB with logging disabled; 6 KB with logging enabled
+- Qualcomm QCA4020: 9 KB
+- Nordic nFS52: 10 KB
+
+For ESP32 users with multi-core processors, the `coreId` setting allows pinning the worker to a specific CPU core. By default, the ESP32 task scheduler redistributes worker tasks across cores to balance performance, which is usually the optimal setting. ESP32 normally runs Wi-Fi/BLE and system daemons on core 0, so pinning a worker on core 1 may improve real-time performance. `xsbug` displays the cores and you can visually see each processor's usage.
+
 
 ### Sending a message to a worker
 Messages to workers are JavaScript objects and binary data.
@@ -200,7 +209,7 @@ Depending on the host runtime, workers may be preemptively scheduled (e.g. run i
 
 The Web Worker specification requires assumes that all Workers are preemptively scheduled. On some microcontrollers, preemptive scheduling is impractical (too much memory required) or nearly impossible (not supported by the host RTOS).
 
-Each host of the Moddable SDK runtime decided whether to support multiple virtual machines. If it does, it then decides whether to support preemptive or cooperative scheduling.  The ESP8266 runtime is built on a cooperative task model and so implements cooperative scheduling of virtual machines. The ESP32 is built on FreeRTOS, a preemptively scheduled RTOS, an so supports preemptive scheduling. When deciding whether to use multiple virtual machines in a project, check to see what is supported by the host runtime.
+Each host of the Moddable SDK runtime decided whether to support multiple virtual machines. If it does, it then decides whether to support preemptive or cooperative scheduling.  The ESP8266 runtime is built on a cooperative task model and so implements cooperative scheduling of virtual machines. The ESP32, Qualcomm QCA4020, and Nordic nRF52 runtimes are built on FreeRTOS, a preemptively scheduled RTOS, and so support preemptive scheduling. For FreeRTOS, workers run at priority 1 (0 is the lowest level priority). When deciding whether to use multiple virtual machines in a project, check to see what is supported by the host runtime.
 
 ## xsbug support
 The debugger for the XS virtual machine, `xsbug`, supports working with multiple virtual machines simultaneously. Each virtual machine appears in a separate tab with the name of the module path used to initialize the worker.

--- a/documentation/xs/XS in C.md
+++ b/documentation/xs/XS in C.md
@@ -2007,8 +2007,6 @@ typedef struct {
 	xsIntegerValue parserTableModulo;
 	xsIntegerValue staticSize;
 	xsIntegerValue nativeStackSize;
-	xsIntegerValue coreId;
-	xsIntegerValue priority;
 } xsCreation;
 ```
 

--- a/documentation/xs/XS in C.md
+++ b/documentation/xs/XS in C.md
@@ -2007,6 +2007,7 @@ typedef struct {
 	xsIntegerValue parserTableModulo;
 	xsIntegerValue staticSize;
 	xsIntegerValue nativeStackSize;
+    xsIntegerValue coreId;
 } xsCreation;
 ```
 

--- a/documentation/xs/XS in C.md
+++ b/documentation/xs/XS in C.md
@@ -2007,7 +2007,8 @@ typedef struct {
 	xsIntegerValue parserTableModulo;
 	xsIntegerValue staticSize;
 	xsIntegerValue nativeStackSize;
-    xsIntegerValue coreId;
+	xsIntegerValue coreId;
+	xsIntegerValue priority;
 } xsCreation;
 ```
 
@@ -2615,34 +2616,34 @@ The value of `xsThis` in the implementation of `xs_restart` matches the receiver
 <a id="license"></a>
 ## License
     Copyright (c) 2016-2025  Moddable Tech, Inc.
-
+    
     This file is part of the Moddable SDK Runtime.
-
+    
     The Moddable SDK Runtime is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-
+    
     The Moddable SDK Runtime is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-
+    
     You should have received a copy of the GNU Lesser General Public License
     along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
-
+    
     This file incorporates work covered by the following copyright and
     permission notice:
-
+    
         Copyright (C) 2010-2016 Marvell International Ltd.
         Copyright (C) 2002-2010 Kinoma, Inc.
-
+    
         Licensed under the Apache License, Version 2.0 (the "License");
         you may not use this file except in compliance with the License.
         You may obtain a copy of the License at
-
+    
          http://www.apache.org/licenses/LICENSE-2.0
-
+    
         Unless required by applicable law or agreed to in writing, software
         distributed under the License is distributed on an "AS IS" BASIS,
         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/examples/base/worker/main.js
+++ b/examples/base/worker/main.js
@@ -30,7 +30,9 @@ function start() {
 			initial: 64,
 			incremental: 32
 		},
-		stack: 64
+		stack: 64,
+		core: 1,
+		priority: 1
 	});
 
 	aWorker.postMessage({hello: "world", index: ++index});
@@ -39,9 +41,11 @@ function start() {
 
 	aWorker.onmessage = function(message) {
 		if (3 === message.counter) {
-			trace(`start worker ${index}\n`);
+			trace(`${JSON.stringify(message)} - 3rd message received, starting worker ${index}\n`);
 			aWorker.terminate();
 			start();
+		} else {
+			trace(`message: ${JSON.stringify(message)}\n`);
 		}
 	}
 }

--- a/examples/base/worker/simpleworker.js
+++ b/examples/base/worker/simpleworker.js
@@ -15,5 +15,6 @@
 let counter = 0
 
 self.onmessage = function(msg) {
+	trace(`simple worker: ${JSON.stringify(msg)} - message received\n`);
 	self.postMessage({hello: "from simple worker", counter: ++counter});
 }

--- a/examples/base/workerclass/coreworker.js
+++ b/examples/base/workerclass/coreworker.js
@@ -1,0 +1,9 @@
+import { SimpleWorker  } from "simpleworker";
+
+/*
+ * coreworker.js
+ * Runs INSIDE the worker context. Uses global onmessage/postMessage.
+ * This is where you respond to main-thread messages.
+ */
+
+self.onmessage = SimpleWorker.prototype.onmessage.bind(self);

--- a/examples/base/workerclass/main.js
+++ b/examples/base/workerclass/main.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016-2023  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK.
+ *
+ *   This work is licensed under the
+ *       Creative Commons Attribution 4.0 International License.
+ *   To view a copy of this license, visit
+ *       <http://creativecommons.org/licenses/by/4.0>.
+ *   or send a letter to Creative Commons, PO Box 1866,
+ *   Mountain View, CA 94042, USA.
+ *
+ */
+
+import { SimpleWorker } from "simpleworker";
+
+trace("main.js: hello\n");
+
+let index = 0
+
+function start() {
+	// note: chunk, heap (slots), and stack are very small - most real-world workers will require different settings
+	trace("main.js: Starting, creating worker\n");
+	const aWorker = new SimpleWorker("coreworker", {
+		static: 8 * 1024,		// total bytes for slots and chunks, in bytes
+		chunk: {				// size in bytes, for strings, array buffers
+			initial: 1536,
+			incremental: 256
+		},
+		heap: {					// in 16 byte slots
+			initial: 128,		// 2K bytes
+			incremental: 32
+		},
+		stack: 128				// number of 16 byte slots
+	});
+	trace("main.js: Worker created\n");
+	aWorker.postMessage({hello: "world", index: ++index});
+	aWorker.postMessage("hello, again");
+	aWorker.postMessage([1, 2, 3]);
+	trace("main.js: Messages sent\n");
+	aWorker.onmessage = function(message) {
+		trace(`main.js: worker -> ${JSON.stringify(message)}\n`);
+		if (3 === message.counter) {
+			trace(`main.js: restarting worker ${index}\n`);
+			aWorker.terminate();
+			start();
+		}
+	}
+}
+
+start();

--- a/examples/base/workerclass/manifest.json
+++ b/examples/base/workerclass/manifest.json
@@ -1,0 +1,31 @@
+{
+  "include": [
+		"$(MODDABLE)/examples/manifest_base.json",
+		"$(MODULES)/base/worker/manifest.json"
+	],
+  	"creation": {
+		"static": 12288,
+		"chunk": {
+			"initial": 1536,
+			"incremental": 512
+		},
+		"heap": {
+			"initial": 64,
+			"incremental": 32
+		},
+		"stack": 128,
+		"keys": {
+			"available": 32,
+			"name": 53,
+			"symbol": 3
+		},
+		"main": "main"
+	},
+  "modules": {
+    "*": [
+      "./main",
+      "./simpleworker",
+      "./coreworker"
+    ]
+  }
+}

--- a/examples/base/workerclass/simpleworker.js
+++ b/examples/base/workerclass/simpleworker.js
@@ -1,0 +1,15 @@
+/*
+ * SimpleWorker: main-thread wrapper that subclasses Worker.
+ * This class lives on the main side. The *worker-side* logic is in "coreworker.js".
+ */
+
+import Worker from "worker";
+
+export class SimpleWorker extends Worker {
+  static counter = 0;
+
+  onmessage(msg) {
+      trace(`simpleworker.js: counter: ${SimpleWorker.counter} message: ${JSON.stringify(msg)}\n`);
+      this.postMessage({hello: "from simple worker", counter: ++SimpleWorker.counter});
+  }
+}

--- a/modules/base/worker/modWorker.c
+++ b/modules/base/worker/modWorker.c
@@ -264,6 +264,10 @@ static void workerConstructor(xsMachine *the, xsBooleanValue shared)
 				getIntegerProperty(the, &xsVar(0), xsID_symbol, &worker->creation.symbolModulo);
 			}
 			getIntegerProperty(the, &xsArg(1), xsID_nativeStack, &worker->creation.nativeStackSize);
+			worker->creation.coreId = -1;		// tskNO_AFFINITY
+#if ESP32	// Multicore only supported on ESP32
+			getIntegerProperty(the, &xsArg(1), xsID_coreId, &worker->creation.coreId);
+#endif
 		}
 	}
 
@@ -280,8 +284,15 @@ static void workerConstructor(xsMachine *the, xsBooleanValue shared)
 #elif nrf52
 	#define kStack (10 * 1024)
 #endif
-	xTaskCreate(workerLoop, worker->module, (worker->creation.nativeStackSize ? worker->creation.nativeStackSize : kStack) / sizeof(StackType_t),
+	// FreeRTOS Task Creation. If we are specifying a core, use that, otherwise use the FreeRTOS xTaskCreate.
+	if (worker->creation.coreId != -1) {	// Use specified core
+		xTaskCreatePinnedToCore(workerLoop, worker->module, (worker->creation.nativeStackSize ? worker->creation.nativeStackSize : kStack) / sizeof(StackType_t),
+							worker, kWorkerTaskPriority, &worker->task, worker->creation.coreId);
+	}
+	else {	// Use default core
+		xTaskCreate(workerLoop, worker->module, (worker->creation.nativeStackSize ? worker->creation.nativeStackSize : kStack) / sizeof(StackType_t),
 							worker, kWorkerTaskPriority, &worker->task);
+	}
 
 	modMachineTaskWait(the);
 #else // !INC_FREERTOS_H

--- a/modules/base/worker/modWorker.c
+++ b/modules/base/worker/modWorker.c
@@ -34,7 +34,8 @@
 	#include "freertos/FreeRTOS.h"
 	#include "freertos/task.h"
 	#include "freertos/semphr.h"
-
+	//#include <esp_log.h>
+	//static const char *TAG = "modWorker";
 	static void workerLoop(void *pvParameter);
 #elif qca4020 || nrf52
 	#include "FreeRTOS.h"
@@ -265,14 +266,19 @@ static void workerConstructor(xsMachine *the, xsBooleanValue shared)
 			}
 			getIntegerProperty(the, &xsArg(1), xsID_nativeStack, &worker->creation.nativeStackSize);
 			worker->creation.coreId = -1;		// tskNO_AFFINITY
+#ifdef INC_FREERTOS_H
 #if ESP32	// Multicore only supported on ESP32
 			getIntegerProperty(the, &xsArg(1), xsID_coreId, &worker->creation.coreId);
+#endif
+#define kWorkerTaskPriority		(tskIDLE_PRIORITY + 1) // Default priority is tskIDLE_PRIORITY + 1
+			getIntegerProperty(the, &xsArg(1), xsID_priority, &worker->creation.priority);
+			if (worker->creation.priority == 0)
+				worker->creation.priority = kWorkerTaskPriority;
 #endif
 		}
 	}
 
 #ifdef INC_FREERTOS_H
-#define kWorkerTaskPriority		(tskIDLE_PRIORITY + 1) 
 #if ESP32
 	#if 0 == CONFIG_LOG_DEFAULT_LEVEL
 		#define kStack ((5 * 1024) + XT_STACK_EXTRA_CLIB)
@@ -285,13 +291,15 @@ static void workerConstructor(xsMachine *the, xsBooleanValue shared)
 	#define kStack (10 * 1024)
 #endif
 	// FreeRTOS Task Creation. If we are specifying a core, use that, otherwise use the FreeRTOS xTaskCreate.
-	if (worker->creation.coreId != -1) {	// Use specified core
+	if (worker->creation.coreId != -1) {	// Use specified core, only for ESP32 for now
+		//ESP_LOGI(TAG, "Creating worker task on core %d with priority %d\n", worker->creation.coreId, worker->creation.priority);
 		xTaskCreatePinnedToCore(workerLoop, worker->module, (worker->creation.nativeStackSize ? worker->creation.nativeStackSize : kStack) / sizeof(StackType_t),
-							worker, kWorkerTaskPriority, &worker->task, worker->creation.coreId);
+							worker, worker->creation.priority, &worker->task, worker->creation.coreId);
 	}
 	else {	// Use default core
+		//ESP_LOGI(TAG, "Creating worker task with default core and priority %d\n", worker->creation.priority);
 		xTaskCreate(workerLoop, worker->module, (worker->creation.nativeStackSize ? worker->creation.nativeStackSize : kStack) / sizeof(StackType_t),
-							worker, kWorkerTaskPriority, &worker->task);
+							worker, worker->creation.priority, &worker->task);
 	}
 
 	modMachineTaskWait(the);
@@ -416,11 +424,11 @@ void workerDeliverConnect(xsMachine *the, modWorker worker, uint8_t *message, ui
 	xsCall1(xsVar(0), xsID_push, xsVar(1));
 
 	xsVar(2) = xsmcNewObject();									// e = {}
-	xsmcSet(xsVar(2), xsID_ports, xsVar(0));						// e.ports = ports
+	xsmcSet(xsVar(2), xsID_ports, xsVar(0));					// e.ports = ports
 
 	xsVar(3) = xsNewHostFunction(xs_worker_postfromworker, 1);	// postMessage
 	xsmcSet(xsVar(1), xsID_postMessage, xsVar(3));				// port.postMessage = postMessage
-	xsCall1(xsGlobal, xsID_onconnect, xsVar(2));					// onconnect(e)
+	xsCall1(xsGlobal, xsID_onconnect, xsVar(2));				// onconnect(e)
 
 	//@@ this eats any exception in onconnect... should be propagated?
 	xsEndHost(the);

--- a/modules/base/worker/modWorker.c
+++ b/modules/base/worker/modWorker.c
@@ -149,6 +149,9 @@ static void workerConstructor(xsMachine *the, xsBooleanValue shared)
 	modCriticalSectionDeclare;
 	modWorker worker;
 	char *module = xsmcToString(xsArg(0));
+#ifdef INC_FREERTOS_H
+	xsIntegerValue priority = 0, core = -1;   // core tskNO_AFFINITY
+#endif
 
 	xsmcVars(2);
 
@@ -265,15 +268,14 @@ static void workerConstructor(xsMachine *the, xsBooleanValue shared)
 				getIntegerProperty(the, &xsVar(0), xsID_symbol, &worker->creation.symbolModulo);
 			}
 			getIntegerProperty(the, &xsArg(1), xsID_nativeStack, &worker->creation.nativeStackSize);
-			worker->creation.coreId = -1;		// tskNO_AFFINITY
 #ifdef INC_FREERTOS_H
 #if ESP32	// Multicore only supported on ESP32
-			getIntegerProperty(the, &xsArg(1), xsID_coreId, &worker->creation.coreId);
+			getIntegerProperty(the, &xsArg(1), xsID_core, &core);
 #endif
 #define kWorkerTaskPriority		(tskIDLE_PRIORITY + 1) // Default priority is tskIDLE_PRIORITY + 1
-			getIntegerProperty(the, &xsArg(1), xsID_priority, &worker->creation.priority);
-			if (worker->creation.priority == 0)
-				worker->creation.priority = kWorkerTaskPriority;
+			getIntegerProperty(the, &xsArg(1), xsID_priority, &priority);
+			if (priority == 0)
+				priority = kWorkerTaskPriority;
 #endif
 		}
 	}
@@ -291,15 +293,15 @@ static void workerConstructor(xsMachine *the, xsBooleanValue shared)
 	#define kStack (10 * 1024)
 #endif
 	// FreeRTOS Task Creation. If we are specifying a core, use that, otherwise use the FreeRTOS xTaskCreate.
-	if (worker->creation.coreId != -1) {	// Use specified core, only for ESP32 for now
+	if (core != -1) {	// Use specified core, only for ESP32 for now
 		//ESP_LOGI(TAG, "Creating worker task on core %d with priority %d\n", worker->creation.coreId, worker->creation.priority);
 		xTaskCreatePinnedToCore(workerLoop, worker->module, (worker->creation.nativeStackSize ? worker->creation.nativeStackSize : kStack) / sizeof(StackType_t),
-							worker, worker->creation.priority, &worker->task, worker->creation.coreId);
+							worker, priority, &worker->task, core);
 	}
 	else {	// Use default core
 		//ESP_LOGI(TAG, "Creating worker task with default core and priority %d\n", worker->creation.priority);
 		xTaskCreate(workerLoop, worker->module, (worker->creation.nativeStackSize ? worker->creation.nativeStackSize : kStack) / sizeof(StackType_t),
-							worker, worker->creation.priority, &worker->task);
+							worker, priority, &worker->task);
 	}
 
 	modMachineTaskWait(the);

--- a/xs/includes/xs.h
+++ b/xs/includes/xs.h
@@ -1242,6 +1242,7 @@ struct xsCreationRecord {
 	xsIntegerValue parserTableModulo;
 	xsIntegerValue staticSize;
 	xsIntegerValue nativeStackSize;
+	xsIntegerValue coreId;
 };
 
 #define xsCreateMachine(_CREATION,_NAME,_CONTEXT) \

--- a/xs/sources/xsAll.h
+++ b/xs/sources/xsAll.h
@@ -522,6 +522,7 @@ struct sxCreation {
 	txSize parserTableModulo; /* xs.h */
 	txSize staticSize; /* xs.h */
 	txSize nativeStackSize; /* xs.h */
+	txSize coreId; /* xs.h */
 };
 
 struct sxPreparation {


### PR DESCRIPTION
Added the ability to set FreeRTOS task priority setting for workers, and for ESP32 devices, assigning the worker task to a specific CPU core.
```js
let aWorker = new Worker("simpleworker", {
	static: 8192,		// bytes
	stack: 64,			// JavaScript stack in 16 byte slots
	heap: {				// Values in 16 byte slots
		initial: 64,
		incremental: 32
	},
	nativeStack: 8192,	// host's native "C" stack, in bytes
	priority: 3,		// For FreeRTOS, sets the Worker Task priority
	coreId: 1			// For ESP32, set the execution core. 0 or 1
});
```
Enhanced `worker.md` documentation to reflect the changes.