### PR TITLE
Fix audioout ISR posting and queue-full handling (CoreS3)

### DIFF
--- a/modules/io/audioout/esp32/audioout-esp32.c
+++ b/modules/io/audioout/esp32/audioout-esp32.c
@@ -531,6 +531,7 @@ void xs_audioout_mark_(xsMachine* the, void* it, xsMarkRoot markRoot)
 static bool playedBuffer(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx)
 {
 	AudioOut audioOut = user_ctx;
+	BaseType_t higherPriorityTaskWoken = pdFALSE;
 
 //@@ entire operation on audioOut->bytesWritable should be atomic
 	uint32_t bytesWritable = __atomic_add_fetch(&audioOut->bytesWritable, event->size, __ATOMIC_SEQ_CST);
@@ -547,7 +548,9 @@ static bool playedBuffer(i2s_chan_handle_t handle, i2s_event_data_t *event, void
 				break;
 			bytesAvailable += walker->bytesAvailable;
 			if (bytesAvailable >= audioOut->dma_buf_size) {
-				xTaskNotify(audioOut->task, 1, eSetValueWithOverwrite);	// wake task
+				xTaskNotifyFromISR(audioOut->task, 1, eSetValueWithOverwrite, &higherPriorityTaskWoken);	// wake task
+				if (higherPriorityTaskWoken)
+					portYIELD_FROM_ISR();
 				return false;		// won't invoke audiooutDeliver / onWritable 
 			}
 		}
@@ -556,7 +559,10 @@ static bool playedBuffer(i2s_chan_handle_t handle, i2s_event_data_t *event, void
 	if (!audioOut->callbackPending) {
 		__atomic_add_fetch(&audioOut->useCount, 1, __ATOMIC_SEQ_CST);
 		audioOut->callbackPending = true;
-		modMessagePostToMachine(audioOut->the, C_NULL, 0, audiooutDeliver, audioOut);		
+		if (0 != modMessagePostToMachineFromISR(audioOut->the, audiooutDeliver, audioOut)) {
+			audioOut->callbackPending = false;
+			__atomic_sub_fetch(&audioOut->useCount, 1, __ATOMIC_SEQ_CST);
+		}
 	}
     return false;
 }

--- a/xs/platforms/esp/xsHost.c
+++ b/xs/platforms/esp/xsHost.c
@@ -1035,9 +1035,9 @@ int modMessagePostToMachineFromISR(xsMachine *the, modMessageDeliver callback, v
 	msg.refcon = refcon;
 	msg.embeddedMessage = 0;
 
-	xQueueSendToBackFromISR(the->msgQueue, &msg, &ignore);
-
-	return 0;
+	if (pdTRUE == xQueueSendToBackFromISR(the->msgQueue, &msg, &ignore))
+		return 0;
+	return -1;
 }
 
 void modMessageService(xsMachine *the, int maxDelayMS)


### PR DESCRIPTION
* Moddable SDK: 6.1 + [cores3 microphone feature](https://github.com/Moddable-OpenSource/moddable/pull/1552)
* ESP-IDF: 5.5
* Device: `esp32/m5stack_cores3`

```
cd contributed/conversationalAI
mcconfig -m -i -p esp32/m5stack_cores3`
```

### Issue

ChatAudioIO frequently hangs while playing response audio (audio playback stops mid‑utterance).

### Root Cause
Based on a core dump provided by @stc1988 and subsequent investigation:

* playedBuffer runs in an ISR but called task-context APIs (postMessage / modMessagePostToMachine).
* Queue-full failures from ISR posting were ignored, leaving callbackPending stuck and preventing further delivery.

### Fix

* Use ISR‑safe APIs in the I2S callback (xTaskNotifyFromISR, modMessagePostToMachineFromISR).
* Return failure from modMessagePostToMachineFromISR when the queue is full.
* In audioout, detect this failure and roll back callbackPending/useCount so delivery can retry on the next IRQ.

### Expected Result

* Audio output no longer stalls mid‑utterance; ISR posting failures no longer dead‑lock delivery.

---

Notes / Verification

Confirmed fixed on M5Stack CoreS3. Not yet verified on other targets (e.g., moddable_six).
Concerned about potential impact on other builds/platforms; additional verification is appreciated.