### PR TITLE
Remove redundant _M_LN2 constant and alias

### DIFF
--- a/xs/platforms/pebble/xsHost.h
+++ b/xs/platforms/pebble/xsHost.h
@@ -450,10 +450,8 @@ void *bsearch(const void *key, const void *base, size_t nel, size_t width, int (
 #define M_PI_2      1.57079632679489661923
 #endif
 
-#define _M_LN2        0.693147180559945309417
 #define M_LOG2E     1.4426950408889634074
 #define M_LOG10E    0.43429448190325182765
-#define M_LN2       _M_LN2
 //#define M_LN10      2.30258509299404568402 
 //#define M_PI_2      1.57079632679489661923
 #define M_PI_4      0.78539816339744830962


### PR DESCRIPTION
M_LN2 is now provided by the Pebble libc math headers, so the local define and its intermediate constant are no longer needed.