### PR TITLE
enhance memory safety in DNS parser by adding bounds checks

### DIFF
--- a/modules/network/dns/moddnsparser.c
+++ b/modules/network/dns/moddnsparser.c
@@ -50,20 +50,14 @@ static void *getQuestionByIndex(xsMachine *the, uint8_t index)
 
 	position += 12;
 	while (index--) {
-		while (true) {
-			if (position >= packetEnd)
-				return NULL;
+		while (position < packetEnd) {
 			uint8_t tag = *position++;
 			if (0 == tag)
 				break;
 			if (0xC0 == (tag & 0xC0)) {
-				if (position >= packetEnd)
-					return NULL;
 				position += 1;
 				break;
 			}
-			if (position + tag > packetEnd)
-				return NULL;
 			position += tag;
 		}
 		position += 4;
@@ -93,20 +87,14 @@ static void *getAnswerByIndex(xsMachine *the, uint8_t index)
 	while (index--) {
 		uint16_t rdlength;
 
-		while (true) {
-			if (position >= packetEnd)
-				return NULL;
+		while (position < packetEnd) {
 			uint8_t tag = *position++;
 			if (0 == tag)
 				break;
 			if (0xC0 == (tag & 0xC0)) {
-				if (position >= packetEnd)
-					return NULL;
 				position += 1;
 				break;
 			}
-			if (position + tag > packetEnd)
-				return NULL;
 			position += tag;
 		}
 		position += 10;
@@ -127,13 +115,15 @@ static void *getAnswerByIndex(xsMachine *the, uint8_t index)
 static int parseQname(xsMachine *the, int offset)
 {
 	uint8_t *packetEnd;
-	uint8_t *packetStart = getPacket(the, &packetEnd);
-	xsUnsignedValue packetLength = (xsUnsignedValue)(packetEnd - packetStart);
+	uint8_t *packetStart;
+	xsUnsignedValue packetLength;
 	uint8_t *position;
 	int qnameEndPosition = 0;
 	int hops = 0;
 
-	xsVar(1) = xsNewArray(0);
+	xsVar(1) = xsNewArray(0);	// do this before getPacket: xsNewArray can trigger GC
+	packetStart = getPacket(the, &packetEnd);
+	packetLength = (xsUnsignedValue)(packetEnd - packetStart);
 	position = offset + packetStart;
 	while (true) {
 		char tmp[64];
@@ -169,9 +159,12 @@ static int parseQname(xsMachine *the, int offset)
 		if (position + tag > packetEnd)
 			xsUnknownError("bad name");
 		c_memcpy(tmp, position, tag);
-		xsmcSetStringBuffer(xsVar(2), tmp, tag);
-		xsCall1(xsVar(1), xsID_push, xsVar(2));
 		offset += tag;
+		xsmcSetStringBuffer(xsVar(2), tmp, tag);	// can trigger GC
+		xsCall1(xsVar(1), xsID_push, xsVar(2));	// can trigger GC
+		// re-fetch packet pointer since GC may have moved memory
+		packetStart = getPacket(the, &packetEnd);
+		packetLength = (xsUnsignedValue)(packetEnd - packetStart);
 		position = offset + packetStart;
 	}
 

--- a/modules/network/dns/moddnsparser.c
+++ b/modules/network/dns/moddnsparser.c
@@ -280,13 +280,13 @@ static void parseQuestionOrAnswer(xsMachine *the, uint8_t *position, uint8_t ans
 						uint16_t advance;
 
 						if (position >= rdataEnd)
-							break;
+							xsUnknownError("bad txt");
 						tag = *position++;
 						advance = (uint16_t)tag + 1;
 						if (advance > rdlength)
-							break;
+							xsUnknownError("bad txt");
 						if (position + tag > rdataEnd)
-							break;
+							xsUnknownError("bad txt");
 						offset += advance;
 						rdlength -= advance;
 						c_memcpy(tmp, position, tag);

--- a/modules/network/dns/moddnsparser.c
+++ b/modules/network/dns/moddnsparser.c
@@ -51,13 +51,19 @@ static void *getQuestionByIndex(xsMachine *the, uint8_t index)
 	position += 12;
 	while (index--) {
 		while (true) {
+			if (position >= packetEnd)
+				return NULL;
 			uint8_t tag = *position++;
 			if (0 == tag)
 				break;
 			if (0xC0 == (tag & 0xC0)) {
+				if (position >= packetEnd)
+					return NULL;
 				position += 1;
 				break;
 			}
+			if (position + tag > packetEnd)
+				return NULL;
 			position += tag;
 		}
 		position += 4;
@@ -75,6 +81,9 @@ static void *getAnswerByIndex(xsMachine *the, uint8_t index)
 	uint16_t answers = ((position[6] << 8) | position[7]) + ((position[8] << 8) | position[9]) + ((position[10] << 8) | position[11]);		// including authority and additional records
 	position = getQuestionByIndex(the, 0xff);
 
+	if (NULL == position)
+		return NULL;
+
 	if ((0xff != index) && (index >= answers))
 		return NULL;
 
@@ -85,13 +94,19 @@ static void *getAnswerByIndex(xsMachine *the, uint8_t index)
 		uint16_t rdlength;
 
 		while (true) {
+			if (position >= packetEnd)
+				return NULL;
 			uint8_t tag = *position++;
 			if (0 == tag)
 				break;
 			if (0xC0 == (tag & 0xC0)) {
+				if (position >= packetEnd)
+					return NULL;
 				position += 1;
 				break;
 			}
+			if (position + tag > packetEnd)
+				return NULL;
 			position += tag;
 		}
 		position += 10;
@@ -107,16 +122,26 @@ static void *getAnswerByIndex(xsMachine *the, uint8_t index)
 	return position;
 }
 
+#define kDNSQnameMaxHops 128
+
 static int parseQname(xsMachine *the, int offset)
 {
+	uint8_t *packetEnd;
+	uint8_t *packetStart = getPacket(the, &packetEnd);
+	xsUnsignedValue packetLength = (xsUnsignedValue)(packetEnd - packetStart);
 	uint8_t *position;
 	int qnameEndPosition = 0;
+	int hops = 0;
 
 	xsVar(1) = xsNewArray(0);
-	position = offset + (uint8_t *)getPacket(the, NULL);;
+	position = offset + packetStart;
 	while (true) {
 		char tmp[64];
-		uint8_t tag = *position++;
+		uint8_t tag;
+
+		if (position >= packetEnd)
+			xsUnknownError("bad name");
+		tag = *position++;
 		offset += 1;
 		if (0 == tag) {
 			if (0 == qnameEndPosition)
@@ -124,20 +149,30 @@ static int parseQname(xsMachine *the, int offset)
 			break;
 		}
 		if (0xC0 == (tag & 0xC0)) {
+			int ptr;
+			if (position >= packetEnd)
+				xsUnknownError("bad name");
 			if (0 == qnameEndPosition)
 				qnameEndPosition = offset + 1;
-			offset = ((tag << 8) | *position) & 0x3FFF;		//@@ range check
-			position = offset + (uint8_t *)getPacket(the, NULL);
+			ptr = ((tag << 8) | *position) & 0x3FFF;
+			if ((xsUnsignedValue)ptr >= packetLength)
+				xsUnknownError("bad name");
+			if (++hops > kDNSQnameMaxHops)
+				xsUnknownError("bad name");
+			offset = ptr;
+			position = offset + packetStart;
 			continue;
 		}
 
 		if (tag > 63)
 			xsUnknownError("bad name");
+		if (position + tag > packetEnd)
+			xsUnknownError("bad name");
 		c_memcpy(tmp, position, tag);
 		xsmcSetStringBuffer(xsVar(2), tmp, tag);
 		xsCall1(xsVar(1), xsID_push, xsVar(2));
 		offset += tag;
-		position = offset + (uint8_t *)getPacket(the, NULL);
+		position = offset + packetStart;
 	}
 
 	return qnameEndPosition;
@@ -243,14 +278,24 @@ static void parseQuestionOrAnswer(xsMachine *the, uint8_t *position, uint8_t ans
 			else
 			if (0x0010 == qtype) {	// TXT
 				if (rdlength > 1) {
+					uint8_t *rdataEnd;
 					xsVar(1) = xsNewArray(0);
 					position = offset + (uint8_t *)getPacket(the, NULL);
+					rdataEnd = position + rdlength;
 					while (rdlength > 1) {
 						uint8_t tag;
+						uint16_t advance;
 
+						if (position >= rdataEnd)
+							break;
 						tag = *position++;
-						offset += tag + 1;		//@@ bounds check range
-						rdlength -= tag + 1;
+						advance = (uint16_t)tag + 1;
+						if (advance > rdlength)
+							break;
+						if (position + tag > rdataEnd)
+							break;
+						offset += advance;
+						rdlength -= advance;
 						c_memcpy(tmp, position, tag);
 						xsmcSetStringBuffer(xsVar(2), tmp, tag);
 						xsCall1(xsVar(1), xsID_push, xsVar(2));


### PR DESCRIPTION
Fix memory-safety issues in DNS parsing (bounds checks, pointer validation, integer underflow) to prevent out-of-bounds reads and malformed packet handling issues.