### PR TITLE
fix(pico): resolve build errors for GCC 14+, prebuilt picotool

### DIFF
--- a/tools/mcconfig/make.pico.mk
+++ b/tools/mcconfig/make.pico.mk
@@ -46,7 +46,7 @@ PICO_VID ?= 2e8a
 PICO_PID ?= 000a
 
 # UF2CONV = $(PICO_SDK_DIR)/build/elf2uf2/elf2uf2
-UF2CONV = $(PICO_SDK_DIR)/build/_deps/picotool/picotool
+UF2CONV ?= $(PICO_SDK_DIR)/build/_deps/picotool/picotool
 
 PICO_SUBCLASS ?= rp2040
 

--- a/xs/platforms/pico/xsPlatform.h
+++ b/xs/platforms/pico/xsPlatform.h
@@ -167,4 +167,8 @@ extern uint32_t pico_memory_remaining();
 #endif
 
 
+#ifndef c_abort
+	#define c_abort abort
+#endif
+
 #endif /* __XSPLATFORM__ */


### PR DESCRIPTION
While implementing https://github.com/HipsterBrown/xs-dev/pull/248, I ran into issues trying to build the "hello world" example program. After doing some debugging, I ended up with this working solution. 

The missing c_abort macro will make sure anyone using > version 14 of the ARM GCC toolchain can build programs targeting the pico. The `UF2CONV` enables developers to use prebuilt versions of `picotool` that can be placed in a different directory from the default CMake build path. 