### PR TITLE
simulator: fix screen_begin for ECMA-419 display calling convention

### DIFF
--- a/build/simulators/modules/screen.c
+++ b/build/simulators/modules/screen.c
@@ -625,9 +625,17 @@ void screen_animateColors(xsMachine* the)
 void screen_begin(xsMachine* the)
 {
 	txScreen* screen = xsGetHostData(xsThis);
-	xsIntegerValue x = xsToInteger(xsArg(0));
-	xsIntegerValue y = xsToInteger(xsArg(1));
-	xsIntegerValue width = xsToInteger(xsArg(2));
+	xsIntegerValue x, y, width;
+	if (1 == xsToInteger(xsArgc)) {
+		x = xsToInteger(xsGet(xsArg(0), xsID_x));
+		y = xsToInteger(xsGet(xsArg(0), xsID_y));
+		width = xsToInteger(xsGet(xsArg(0), xsID_width));
+	}
+	else {
+		x = xsToInteger(xsArg(0));
+		y = xsToInteger(xsArg(1));
+		width = xsToInteger(xsArg(2));
+	}
 	screen->rowAddress = screen->buffer + (y * screen->width * screenBytesPerPixel) + (x * screenBytesPerPixel);
 	screen->rowCount = width;
 	screen->rowDelta = (screen->width - width) * screenBytesPerPixel;


### PR DESCRIPTION
Fixes #1579.

`manifest_commodetto.json` includes `$(MODULES)/io/display/manifest.json`, which sets `ECMA419.display: 1` and compiles Poco with `MODDEF_ECMA419_DISPLAY=1`. Under this path, `commodettoPocoCore.c` calls `pixelsOut.begin()` with a single object argument {x, y, width, height} rather than four separate integers.

The simulator's screen_begin was never updated to handle this calling convention. It unconditionally read `xsArg(0)`, `xsArg(1`), and `xsArg(2`) as integers. When called with one object argument, `xsArg(1)` is out of bounds, producing:

```
Break: SyntaxError: C: xsArg(1): invalid index (in @screen_begin)!
```

Real hardware (e.g. Moddable Six) is unaffected because its display driver uses native C function pointer dispatch (displayHooks / pixelsOutDispatch), which bypasses the JavaScript begin() call entirely.

The fix checks the argument count in `screen_begin`: if one argument is passed, it reads x, y, and width from the object's properties; otherwise it falls through to the original integer-argument path, preserving backward compatibility.

