### PR TITLE
feat: enable Linux simulator AudioIn and AudioOut linking

### DIFF
--- a/modules/io/audioin/manifest.json
+++ b/modules/io/audioin/manifest.json
@@ -10,6 +10,9 @@
 			}
 		},
 		"lin": {
+			"build": {
+				"LINUX_AUDIO_LIBS": "-lasound"
+			},
 			"modules": {
 				"*": "$(MODDABLE)/modules/io/common/builtinCommon",
 				"embedded:io/audio/in": "./lin/audioin"

--- a/modules/io/audioout/manifest.json
+++ b/modules/io/audioout/manifest.json
@@ -4,6 +4,9 @@
 	],
 	"platforms": {
 		"lin": {
+			"build": {
+				"LINUX_AUDIO_LIBS": "-lasound"
+			},
 			"modules": {
 				"*": "$(MODDABLE)/modules/io/common/builtinCommon",
 				"embedded:io/audio/out": "./lin/audioout_"

--- a/tools/mcconfig/make.lin.mk
+++ b/tools/mcconfig/make.lin.mk
@@ -125,7 +125,7 @@ endif
 C_INCLUDES += $(DIRECTORIES)
 C_INCLUDES += $(foreach dir,$(XS_DIRECTORIES) $(TMP_DIR),-I$(dir))
 
-C_FLAGS = -fPIC -shared -c $(shell $(PKGCONFIG) --cflags gio-2.0)
+C_FLAGS = -fPIC -shared -c $(shell $(PKGCONFIG) --cflags gio-2.0) $(LINUX_AUDIO_CFLAGS)
 ifeq ($(DEBUG),)
 	C_FLAGS += -D_RELEASE=1 -O3
 else
@@ -133,7 +133,7 @@ else
 #	C_FLAGS += -DMC_MEMORY_DEBUG=1
 endif
 
-LINK_LIBRARIES = -lm -lc $(shell $(PKGCONFIG) --libs gio-2.0) -lpthread
+LINK_LIBRARIES = -lm -lc $(shell $(PKGCONFIG) --libs gio-2.0) -lpthread $(LINUX_AUDIO_LIBS)
 
 LINK_OPTIONS = -fPIC -shared -Wl,-Bdynamic\,-Bsymbolic
 


### PR DESCRIPTION
## Summary

  Enable `embedded:io/audio/in` and `embedded:io/audio/out` on the Linux simulator by linking ALSA only when those modules are used.

  ## Changes

  - add optional Linux audio build variables to `tools/mcconfig/make.lin.mk`
  - request `-lasound` from the Linux `AudioIn` manifest
  - request `-lasound` from the Linux `AudioOut` manifest
  - add `linux-sim-audio.md` with the design note for Linux simulator audio support

  ## Why

  Linux already has ALSA-based implementations for `AudioIn` and `AudioOut`, but simulator apps were not linking against ALSA. As a result, apps using these modules could fail at link time
  or load time with unresolved audio symbols.

  This change wires the existing Linux audio implementations into simulator builds without changing the JS API and without adding ALSA to unrelated simulator apps.

  ## Verification

  Verified on top of the latest `upstream/public`.

  - built `examples/io/audioout/play-sync` for `-p sim/moddable_six`
  - built `examples/io/audioin/capture-sync` for `-p sim/moddable_six`
  - confirmed generated `mc.so` links `libasound.so.2`
  - launched `play-sync` in `mcsim`
  - launched `capture-sync` in `mcsim` and confirmed `recording -> playing -> done`