### PR TITLE
Add pebble/colors module with named GColor8 constants

### DIFF
--- a/build/devices/pebble/host/manifest.json
+++ b/build/devices/pebble/host/manifest.json
@@ -21,6 +21,7 @@
 		"$(MODDABLE)/build/devices/pebble/modules/archive-resource/manifest.json",
 		"$(MODDABLE)/build/devices/pebble/modules/httpclient/manifest.json",
 		"$(MODDABLE)/build/devices/pebble/modules/websocketclient/manifest.json",
+		"$(MODDABLE)/build/devices/pebble/modules/colors/manifest.json",
 		"$(MODDABLE)/modules/piu/Pebble/manifest.json"
 	],
 	"config": {

--- a/build/devices/pebble/modules/colors/manifest.json
+++ b/build/devices/pebble/modules/colors/manifest.json
@@ -1,0 +1,6 @@
+{
+	"modules": {
+		"pebble/colors": "./pebble-colors"
+	},
+	"preload": "pebble/colors"
+}

--- a/build/devices/pebble/modules/colors/pebble-colors.js
+++ b/build/devices/pebble/modules/colors/pebble-colors.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ * 
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ * 
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ * 
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+export const clear               = 0x00;
+
+export const black               = 0xC0;
+export const oxfordBlue          = 0xC1;
+export const dukeBlue            = 0xC2;
+export const blue                = 0xC3;
+export const darkGreen           = 0xC4;
+export const midnightGreen       = 0xC5;
+export const cobaltBlue          = 0xC6;
+export const blueMoon            = 0xC7;
+export const islamicGreen        = 0xC8;
+export const jaegerGreen         = 0xC9;
+export const tiffanyBlue         = 0xCA;
+export const vividCerulean       = 0xCB;
+export const green               = 0xCC;
+export const malachite           = 0xCD;
+export const mediumSpringGreen   = 0xCE;
+export const cyan                = 0xCF;
+
+export const bulgarianRose       = 0xD0;
+export const imperialPurple      = 0xD1;
+export const indigo              = 0xD2;
+export const electricUltramarine = 0xD3;
+export const armyGreen           = 0xD4;
+export const darkGray            = 0xD5;
+export const liberty             = 0xD6;
+export const veryLightBlue       = 0xD7;
+export const kellyGreen          = 0xD8;
+export const mayGreen            = 0xD9;
+export const cadetBlue           = 0xDA;
+export const pictonBlue          = 0xDB;
+export const brightGreen         = 0xDC;
+export const screaminGreen       = 0xDD;
+export const mediumAquamarine    = 0xDE;
+export const electricBlue        = 0xDF;
+
+export const darkCandyAppleRed   = 0xE0;
+export const jazzberryJam        = 0xE1;
+export const purple              = 0xE2;
+export const vividViolet         = 0xE3;
+export const windsorTan          = 0xE4;
+export const roseVale            = 0xE5;
+export const purpureus           = 0xE6;
+export const lavenderIndigo      = 0xE7;
+export const limerick            = 0xE8;
+export const brass               = 0xE9;
+export const lightGray           = 0xEA;
+export const babyBlueEyes        = 0xEB;
+export const springBud           = 0xEC;
+export const inchworm            = 0xED;
+export const mintGreen           = 0xEE;
+export const celeste             = 0xEF;
+
+export const red                 = 0xF0;
+export const folly               = 0xF1;
+export const fashionMagenta      = 0xF2;
+export const magenta             = 0xF3;
+export const orange              = 0xF4;
+export const sunsetOrange        = 0xF5;
+export const brilliantRose       = 0xF6;
+export const shockingPink        = 0xF7;
+export const chromeYellow        = 0xF8;
+export const rajah               = 0xF9;
+export const melon               = 0xFA;
+export const richBrilliantLavender = 0xFB;
+export const yellow              = 0xFC;
+export const icterine            = 0xFD;
+export const pastelYellow        = 0xFE;
+export const white               = 0xFF;


### PR DESCRIPTION
## Summary

Expose all 64 Pebble GColor8 named color constants (plus clear) as a preloaded JavaScript module at "pebble/colors"

proposed usage: 
`  import { cobaltBlue, chromeYellow, white } from "pebble/colors";
`

Each constant is the GColor8 ARGB8 byte value matching the C SDK definitions, usable directly with Poco rendering methods.

## Motivation

render.makeColor(r, g, b) can produce unexpected results for Pebble developers because the 2-bit-per-channel display silently snaps values to the nearest of 64 palette colors, with no indication that the rendered color differs from what was requested.

Named constant

No silent snapping — you're choosing directly from the actual palette, so what you write is exactly what renders
Discoverable — autocomplete shows all 64 available colors
Consistent with the C SDK — C developers already have GColorCobaltBlue, GColorChromeYellow, etc. This brings the JS SDK to parity

## Details
Each export is the GColor8 ARGB8 byte value (e.g. cobaltBlue = 0xC6), matching the C SDK's GColorCobaltBlueARGB8 Values
The module is preloaded into ROM, so it has zero heap cost at runtime
Names use camelCase following JS conventions (C SDK uses PascalCase GColorCobaltBlue)