### PR TITLE
Fix Pico builds with the io umbrella manifest

### DIFF
--- a/modules/io/audioout/pico/audioout-pico.c
+++ b/modules/io/audioout/pico/audioout-pico.c
@@ -31,6 +31,19 @@
 #include "pico/audio_i2s.h"
 #include "modTimer.h"
 
+#ifndef MODDEF_AUDIOOUT_I2S_BITSPERSAMPLE
+	#define MODDEF_AUDIOOUT_I2S_BITSPERSAMPLE 16
+#endif
+#ifndef MODDEF_AUDIOOUT_I2S_DATAOUT_PIN
+	#define MODDEF_AUDIOOUT_I2S_DATAOUT_PIN PICO_AUDIO_I2S_DATA_PIN
+#endif
+#ifndef MODDEF_AUDIOOUT_I2S_BCK_PIN
+	#define MODDEF_AUDIOOUT_I2S_BCK_PIN PICO_AUDIO_I2S_CLOCK_PIN_BASE
+#endif
+#ifndef MODDEF_AUDIOOUT_I2S_LR_PIN
+	#define MODDEF_AUDIOOUT_I2S_LR_PIN (MODDEF_AUDIOOUT_I2S_BCK_PIN + 1)
+#endif
+
 typedef struct AudioOutElementRecord AudioOutElementRecord;
 typedef struct AudioOutElementRecord *AudioOutElement;
 
@@ -576,7 +589,7 @@ int doWrite(AudioOut audioOut, void *audioData, xsUnsignedValue requested)
 		int16_t volumeFixed = audioOut->volumeFixed;
 		int requestedSamples = amt >> 1;		//@@ broken for stereo & 8 bit
 		int16_t *src = (int16_t *)audioData;
-		int16_t *samples = buffer->buffer->bytes + audioOut->bufferPendingPos;
+		int16_t *samples = (int16_t *)(buffer->buffer->bytes + audioOut->bufferPendingPos);
 		int i;
 		for (i=0; i<requestedSamples; i++)
 			samples[i] = (*src++ * volumeFixed) >> 8;

--- a/modules/io/manifest.json
+++ b/modules/io/manifest.json
@@ -15,6 +15,12 @@
 			"include": "./manifests/esp32/manifest.json"
 		},
 		"pico": {
+			"include": "./manifests/pico/manifest.json"
+		},
+		"pico/pico_w": {
+			"include": "./manifests/pico/manifest_net.json"
+		},
+		"pico/pico_2_w": {
 			"include": "./manifests/pico/manifest_net.json"
 		},
 		"nrf52": {

--- a/modules/io/manifests/pico/manifest.json
+++ b/modules/io/manifests/pico/manifest.json
@@ -6,7 +6,7 @@
 		"$(IO)/analog/manifest.json",
 		"$(IO)/audioout/manifest.json",
 		"$(IO)/digital/manifest.json",
-		"$(IO)/i2c/manifest.json"
+		"$(IO)/i2c/manifest.json",
 		"$(IO)/pulsecount/manifest.json",
 		"$(IO)/pwm/manifest.json",
 		"$(IO)/serial/manifest.json",
@@ -18,7 +18,6 @@
 			"$(MODULES)/pins/digital/pico/modGPIO"
 		],
 		"commodetto/Bitmap": "$(COMMODETTO)/commodettoBitmap",
-
 		"system": "$(IO)/system/*"
 	},
 	"preload": [


### PR DESCRIPTION
On v8.0.0, including the umbrella `$(MODDABLE)/modules/io/manifest.json` in a project targeted at `-p pico` fails to build for the original RP2040 Raspberry Pi Pico (no Wi-Fi). This worked in v7.2.1.

**Repro:**

`manifest.json`:
```json
{
  "include": [
    "$(MODDABLE)/examples/manifest_base.json",
    "$(MODDABLE)/modules/io/manifest.json"
  ],
  "modules": { "*": "./main" }
}
```

`main.js` uses only `embedded:io/pwm` + `timer`.

```
mcconfig -d -m -p pico
```

**Errors seen:**

1. `fatal error: pico/cyw43_arch.h: No such file or directory` (modNet.c)
2. `fatal error: lwip/tcp.h: No such file or directory` (modResolve.c)
3. `MODDEF_AUDIOOUT_I2S_DATAOUT_PIN undeclared` / `MODDEF_AUDIOOUT_I2S_BCK_PIN undeclared` / `#error LR_PIN must be BCK_PIN + 1` (audioout-pico.c)
4. `initialization of 'int16_t *' from incompatible pointer type 'uint8_t *'` (audioout-pico.c:579)

**Fixes:**

1. `modules/io/manifest.json` — bare `pico` platform should not force networking

Before, the bare `pico` platform unconditionally included `manifests/pico/manifest_net.json`, which pulls `examples/manifest_net.json` and compiles `modNet.c` / `modResolve.c`. Those require `pico/cyw43_arch.h` and `lwip/*` — headers that only exist when the build is configured for the CYW43 radio (Pico W / Pico 2 W). This has been resolved by pointing the default `pico` target to the original `$(IO)/manifests/pico/manifest.json` and the compatible wireless boards to the new manifest_net.json for the pico. This seems to be a unique case for the pico since the other platforms are "all or nothing" when it comes to wireless connectivity. 

2. `modules/io/audioout/pico/audioout-pico.c` — guard `MODDEF_AUDIOOUT_I2S_*` defines

The pico audioout source unconditionally references `MODDEF_AUDIOOUT_I2S_DATAOUT_PIN`, `MODDEF_AUDIOOUT_I2S_BCK_PIN`, `MODDEF_AUDIOOUT_I2S_LR_PIN`, and `MODDEF_AUDIOOUT_I2S_BITSPERSAMPLE`, but no manifest provides defaults — so any project pulling in audioout without explicit pin overrides fails to compile.

The esp32 audioout driver already follows the `#ifndef`-with-default pattern, so this PR applies it to pico, defaulting to the pin macros pico-extras already exposes. Pico-extras conventionally sets `PICO_AUDIO_I2S_DATA_PIN=9` and `PICO_AUDIO_I2S_CLOCK_PIN_BASE=10`, matching the Pimoroni Pico Audio Pack pinout. Existing manifests that already define these macros are unaffected.

3. `modules/io/audioout/pico/audioout-pico.c:579` — pointer-type mismatch in `doWrite`

`buffer->buffer->bytes` is `uint8_t *`; assigning into `int16_t *` is an `-Wincompatible-pointer-types` error under recent GCC. The arithmetic is intentionally byte-offset, so the fix is applying an explicit cast. 

---

I have tested these fixes only with my local test program on the Pico. I don't have a Pico W or Pico 2W to test with at the moment. 
