### PR TITLE
fix(mcpack): replicate external subplatform support from mcmanifest

### DIFF
--- a/tools/mcpack.js
+++ b/tools/mcpack.js
@@ -171,16 +171,40 @@ export default class extends TOOL {
 				if (this.platform)
 					throw new Error("-p '" + name + "': too many platforms!");
 				name = name.toLowerCase();
-				let parts = name.split("/");
+
+				const slashIndex = name.indexOf("/"), colonIndex = name.indexOf(":");
+				const splitOn = ((colonIndex > 0) && ((slashIndex < 0) || (colonIndex < slashIndex))) ? ":" : "/";
+				const parts = name.split(splitOn);
 				if ("esp8266" === parts[0])
 					parts[0] = "esp";
 				else if ((parts[0] == "sim") || (parts[0] == "simulator"))
 					parts[0] = this.currentPlatform;
 				this.platform = parts[0];
 				if (parts[1]) {
-					this.subplatform = parts[1];
-					this.environment.SUBPLATFORM = this.subplatform;
-					this.fullplatform = this.platform + "/" + this.subplatform;
+					if ("/" === splitOn) {
+						this.subplatform = parts[1];
+						this.environment.SUBPLATFORM = this.subplatform;
+						this.environment.SUBPLATFORMDIRECTORY = this.buildPath + this.slash + "devices" + this.slash + this.platform + this.slash + "targets" + this.slash + this.subplatform;
+						this.environment.SUBPLATFORMMANIFEST = this.environment.SUBPLATFORMDIRECTORY + this.slash + "manifest.json";
+						this.fullplatform = this.platform + "/" + this.subplatform;
+					}
+					else if (":" === splitOn) {
+						let dir = parts[1];
+						if (dir.startsWith("~" + this.slash) && this.getenv("HOME"))
+							dir = dir.replace("~", this.getenv("HOME"));
+						this.environment.SUBPLATFORMDIRECTORY = this.resolveDirectoryPath(dir);
+						this.environment.SUBPLATFORMMANIFEST = this.environment.SUBPLATFORMDIRECTORY + this.slash + "manifest.json";
+						try {
+							const manifest = JSON.parse(this.readFileString(this.environment.SUBPLATFORMMANIFEST));
+							this.subplatform = manifest.build?.SUBPLATFORM ?? this.environment.SUBPLATFORMDIRECTORY.split(this.slash).at(-1);
+						}
+						catch {
+							throw new Error("invalid subplatform manfest path: " + parts[1]);
+						}
+
+						this.environment.SUBPLATFORM = this.subplatform;
+						this.fullplatform = this.platform + "/" + this.subplatform;
+					}
 					this.environment.PLATFORMPATH = this.platform + this.slash + this.subplatform;
 				}
 				else {


### PR DESCRIPTION
External subplatform (a.k.a custom device targets) support was added in Moddable v8.1.0 but only in mcmanifest.js for `mcconfig` to resolve. This PR creates parity support for `mcpack` as well. 