### PR TITLE
add pebble exit() method

### DIFF
--- a/build/devices/pebble/modules/global/global.js
+++ b/build/devices/pebble/modules/global/global.js
@@ -202,6 +202,7 @@ export class Pebble {
 	get launch() {return native("xs_global_launch_get").call(this);}
 	get wake() {return native("xs_global_wake_get").call(this);}
 
+	exit(reason) { return native("xs_global_exit").call(this, reason); }
 }
 
 export default Pebble;

--- a/build/devices/pebble/modules/global/pebble-global.c
+++ b/build/devices/pebble/modules/global/pebble-global.c
@@ -27,6 +27,7 @@
 #include "applib/app_light.h"
 #include "applib/app_watch_info.h"
 #include "applib/connection_service.h"
+#include "applib/ui/app_window_stack.h"
 #include "process_state/app_state/app_state.h"
 
 static void connectionChanged(bool connected)
@@ -223,4 +224,11 @@ void xs_global_light(xsMachine *the)
 		app_light_enable_interaction();
 	else
 		app_light_enable(xsmcTest(xsArg(0)));
+}
+
+void xs_global_exit(xsMachine *the)
+{
+    if (xsmcArgc >= 1 && xsmcTest(xsArg(0)))
+        app_exit_reason_set(xsmcToInteger(xsArg(0)));
+    app_window_stack_pop_all(true);
 }


### PR DESCRIPTION
This allows a pebble app to exit, especially useful if it has overridden the back button.