### PR TITLE
Add 'info instruments' help entry to xsdb

### DIFF
--- a/tools/xsbug-log/xsbug-debugmachine.js
+++ b/tools/xsbug-log/xsbug-debugmachine.js
@@ -2844,7 +2844,8 @@ class DebugMachine extends Machine {
 						{ keys: "eval <expr>", desc: "Evaluate JavaScript expression in current frame" },
 						{ keys: "info modules", desc: "List loaded modules" },
 						{ keys: "info module name", desc: "Show exports" },
-						{ keys: "info modules.name.path", desc: "Navigate into module exports" }
+						{ keys: "info modules.name.path", desc: "Navigate into module exports" },
+						{ keys: "info instruments", desc: "Print instrument snapshots" }
 					]
 				},
 				{


### PR DESCRIPTION
Recently, in development, I’ve been trying to have an AI agent use xsdb to verify its behavior. Since I’m instructing it to look up how to use xsdb on its own via the help command, writing good help documentation is important.