### PR TITLE
fix base64 decode heap overflow on stray padding

### DIFF
--- a/modules/data/base64/modBase64.c
+++ b/modules/data/base64/modBase64.c
@@ -109,10 +109,6 @@ void xs_base64_decode(xsMachine *the)
 	srcSize = c_strlen((char *)src);
 
 	dstSize = (srcSize / 4) * 3;
-	if (c_read8(src + srcSize - 1) == '=')
-		dstSize--;
-	if (c_read8(src + srcSize - 2) == '=')
-		dstSize--;
 	srcIndex = 0;
 
 	xsmcSetArrayBufferResizable(xsResult, NULL, dstSize, dstSize);

--- a/tests/modules/data/base64/decode.js
+++ b/tests/modules/data/base64/decode.js
@@ -23,6 +23,9 @@ assert.sameValue(1, Base64.decode("Zg==").byteLength, "remove extra bytes from p
 assert.sameValue(1, Base64.decode("Zg==\n\n\n\n\n\n\n\n\n\n").byteLength, "remove extra bytes from trailing garbage");
 assert.sameValue(1, Base64.decode("\n\n\n\n\n\n\n\n\n\nZg==").byteLength, "remove extra bytes from leading garbage");
 
+assert.sameValue(3, Base64.decode("AAAA=").byteLength, "stray padding after a full quantum must not overrun output");
+assert.sameValue(6, Base64.decode("AAAAAAAA==").byteLength, "stray padding after full quanta must not overrun output");
+
 let b = Base64.decode(12.21);
 assert.sameValue(b.byteLength, 3);
 b = new Uint8Array(b);


### PR DESCRIPTION
Repro: `Base64.decode("AAAA=")` (or `"AAAAAAAA=="`).
Expected: 3 decoded bytes from the `AAAA` quantum, stray `=` ignored.
Actual: heap-buffer-overflow. `xs_base64_decode` sizes the buffer as `(srcSize / 4) * 3` then decrements once per trailing `=`, but the decode loop skips a `=` that lands on a quantum boundary (`srcIndex` 0 or 1) instead of treating it as padding, so it still emits 3 bytes for each preceding full group. Allocation is 2, three bytes get written.
Cause: the padding decrements assume every `=` shortens the last group, which is false for stray padding, so the estimate falls below the bytes actually produced.
Fix: drop the decrements so the allocation stays a true upper bound; the existing `xsmcSetArrayBufferLength` call already trims the result to the exact decoded length, so valid padded input is unaffected. The XS core (`fxUint8ArrayFromBase64`) and `JSONBase64Parser` already round up rather than subtract.

Confirmed under ASan with a standalone copy of the decode loop: pre-patch `AAAA=` allocates 2 and writes 3 (`WRITE of size 1 ... 0 bytes after 2-byte region`); post-patch writes never exceed the allocation and padded inputs keep their lengths (`QQ==` -> 1, `QUJDRA==` -> 4).