### PR TITLE
Fix request header forwarding in pebbleproxy

### DIFF
--- a/build/devices/pebble/modules/httpclient/httpclient-pebble.js
+++ b/build/devices/pebble/modules/httpclient/httpclient-pebble.js
@@ -235,7 +235,8 @@ class HTTPClient {
 							current.sending = parseInt(item.value[1]);
 						else if (("transfer-encoding" === item.value[0]) && ("chunked" === item.value[1].toLowerCase()))
 							current.sending = true;		// unknown length
-						this.#remain = ArrayBuffer.fromString(`${item.value[0]}:${item.value[1]}\n`);
+						this.#remain = ArrayBuffer.fromString(`${current.sentHeader ? "\n" : ""}${item.value[0]}:${item.value[1]}`);
+						current.sentHeader = true;
 						this.#remain = new Uint8Array(this.#remain);
 						this.#remain.part = 3;
 						this.#remain.position = 0;

--- a/build/devices/pebble/npm/pebbleproxy/proxy.js
+++ b/build/devices/pebble/npm/pebbleproxy/proxy.js
@@ -173,8 +173,10 @@ function httpMessage(id, e) {
 			request.xhr.responseType = 'arraybuffer';
 
 			request.headers.split("\n").forEach(line => {
-				const [key, value] = line.split(":");
-				request.xhr.setRequestHeader(key, value);
+				const colon = line.indexOf(":");
+				if (colon <= 0)
+					return;		// skip empty lines, including the serializer's trailing newline
+				request.xhr.setRequestHeader(line.slice(0, colon), line.slice(colon + 1));
 			});
 
 			request.xhr.onload = function () {


### PR DESCRIPTION
Empty header lines and colons in header values broke every fetch(). Skip empty lines, split on the first colon only, and emit "\n" between headers instead of after each.