### PR TITLE
bound recovery scan to input end in xs_textdecoder_decode

### DIFF
--- a/modules/data/text/decoder/textdecoder.c
+++ b/modules/data/text/decoder/textdecoder.c
@@ -187,10 +187,17 @@ void xs_textdecoder_decode(xsMachine *the)
 			else if (first > 0xF4)	// no valid next byte
 				clen = 0;
 
+			const uint8_t *s = &utf8[1];
 			while (clen-- > 0) {
-				uint8_t c = c_read8(src);
-				if ((lower <= c) && (c <= upper))
-					src++;
+				uint8_t c = *s++;
+				if ((lower <= c) && (c <= upper)) {
+					if (bufferLength) {
+						bufferLength--;
+						buffer++;
+					}
+					else
+						src++;
+				}
 				else
 					break;
 			}
@@ -321,10 +328,17 @@ void xs_textdecoder_decode(xsMachine *the)
 			else if (first > 0xF4)	// no valid next byte
 				clen = 0;
 
+			const uint8_t *s = &utf8[1];
 			while (clen-- > 0) {
-				uint8_t c = c_read8(src);
-				if ((lower <= c) && (c <= upper))
-					src++;
+				uint8_t c = *s++;
+				if ((lower <= c) && (c <= upper)) {
+					if (bufferLength) {
+						bufferLength--;
+						buffer++;
+					}
+					else
+						src++;
+				}
 				else
 					break;
 			}

--- a/tests/modules/data/text/decoder/decodestream.js
+++ b/tests/modules/data/text/decoder/decodestream.js
@@ -46,3 +46,12 @@ assert.sameValue("\uFFFD", decoder.decode());
 
 assert.sameValue("", decoder.decode(Uint8Array.of(0xF0, 0x9F, 0x92), {stream: true}));
 assert.sameValue("\uFFFD", decoder.decode());
+
+// illegal sequence spanning a buffered partial lead and a short final chunk:
+// the recovery scan must consume from the buffered bytes before src and stop at the
+// end of the input. The chunk is a view whose backing store holds continuation bytes
+// (0x90) past its length, so the bytes seen are F0 80 90 90: the 0x80 is below the
+// 0x90 lower bound for an F0 lead, so it and the two trailing 0x90 each decode to U+FFFD.
+assert.sameValue("", decoder.decode(Uint8Array.of(0xF0, 0x80), {stream: true}));
+assert.sameValue("\uFFFD\uFFFD\uFFFD\uFFFD", decoder.decode(new Uint8Array(8).fill(0x90).subarray(0, 2), {stream: true}));
+assert.sameValue("", decoder.decode());


### PR DESCRIPTION
the illegal-sequence recovery loop in `xs_textdecoder_decode` scans continuation bytes without checking `src < srcEnd`, so a streaming `decode()` that finishes a buffered partial lead with a short final chunk runs `src` past the input and passes a negative length to the trailing `c_memcpy`; caught with an asan build of xst.