### PR TITLE
reject png bit depths that overflow the scanline slop

### DIFF
--- a/modules/commodetto/commodettoReadPNG.c
+++ b/modules/commodetto/commodettoReadPNG.c
@@ -252,6 +252,8 @@ void xs_PNG_constructor(xsMachine *the)
 				png->filterBytesPerPixel = (bitsPerPixel + 7) >> 3;
 
 				//@@ check for supported combinations
+				if ((0 == png->channelCount) || (png->bitDepth > 8) || (0 == png->bitDepth))
+					xsErrorPrintf("unsupported");
 
 				png->scanLineByteCount = (png->width * bitsPerPixel + 7) >> 3;
 				png->scanBuffers = c_malloc((png->scanLineByteCount + kScanLineSlop) * 2);


### PR DESCRIPTION
`xs_PNG_constructor` never validates the IHDR bit depth, so a png with more than 8 bits per channel makes `filterBytesPerPixel` exceed the fixed `kScanLineSlop` and the leftmost-pixel `prev = pix - bpp` read in the `subFilter`/`paethFilter` unfilter step runs before the scanline allocation, found with an asan build decoding a 16-bit rgba png.