### PR TITLE
Revert the removal of startupSound and startupVibration.

### DIFF
--- a/build/devices/esp32/targets/m5stack_core2/manifest.json
+++ b/build/devices/esp32/targets/m5stack_core2/manifest.json
@@ -17,6 +17,8 @@
 	],
 	"config": {
 		"screen": "ili9341",
+		"startupSound": "bflatmajor.maud",
+		"startupVibration": 600,
 		"enablePowerButton": false
 	},
 	"defines": {


### PR DESCRIPTION
In #1624, I accidentally committed the settings I used for testing, so I’m reverting them.