### PR TITLE
Include esnext.disposable in tsconfig libs

### DIFF
--- a/tools/mcmanifest.js
+++ b/tools/mcmanifest.js
@@ -1835,7 +1835,7 @@ export class TSConfigFile extends PrerequisiteFile {
 				module: "preserve",
 				resolveJsonModule: true,
 				paths,
-				lib: ["es2025"],
+				lib: ["es2025", "esnext.disposable"],
 				sourceMap: true,
 				target: "es2025"
 			};
@@ -1889,7 +1889,7 @@ export class TSConfigFile extends PrerequisiteFile {
 				outDir: tool.modulesPath,
 				paths: {
 				},
-				lib: ["es2025"],
+				lib: ["es2025", "esnext.disposable"],
 				sourceMap: true,
 				target: "es2025"
 			},


### PR DESCRIPTION
When I built a TypeScript project with Moddable 8.3.0, I ran into the following error.

 ```
../../../moddable/typings/embedded_io/serial.d.ts:59:28 - error TS2304: Cannot find name 'Disposable'.

59   interface Serial extends Disposable {}
```

The tsconfig generated by mcmanifest was missing `esnext.disposable`, so I added it.


