### PR TITLE
piu typings: fix onTouchEnded typo, Image.frameCount, firstThat/lastThat return

### DIFF
--- a/typings/piu/MC-types.d.ts
+++ b/typings/piu/MC-types.d.ts
@@ -77,7 +77,7 @@ export interface Behavior<T extends Content = Content> {
     onTimeChanged?(content: T): void;
     onTouchBegan?(content: T, id: number, x: number, y: number, ticks: number): void;
     onTouchCancelled?(content: T, id: number): void;
-    onTouchended?(content: T, id: number, x: number, y: number, ticks: number): void;
+    onTouchEnded?(content: T, id: number, x: number, y: number, ticks: number): void;
     onTouchMoved?(content: T, id: number, x: number, y: number, ticks: number): void;
     // TODO: complete callbacks
   }
@@ -259,9 +259,9 @@ export interface Container extends Content {
     add(content: Content): void;
     content(at: number | string): Content | undefined;
     empty(start?: number, stop?: number): void;
-    firstThat(id: string, ...extras: any[]): void;
+    firstThat(id: string, ...extras: any[]): Content | undefined;
     insert(content: Content, before: Content): void;
-    lastThat(id: string, ...extras: any[]): void;
+    lastThat(id: string, ...extras: any[]): Content | undefined;
     remove(content: Content): void;
     replace(content: Content, by: Content): void;
     run(transition: Transition, ...extras: any[]): void;
@@ -454,7 +454,7 @@ export interface LayoutConstructor extends ContainerConstructor {
 }
 
 export interface Image extends Content {
-  readonly frameCount: never;
+  readonly frameCount: number;
   frameIndex: number;
 }
 export interface ImageDictionary extends ContentDictionary {


### PR DESCRIPTION
## Summary

Three small, verified bug fixes in the Piu MC TypeScript definitions (`typings/piu/MC-types.d.ts`). No runtime code is touched.

- **`Behavior.onTouchended` → `onTouchEnded`** — the callback was mis-spelled, so the typed handler never matched Piu's actual `onTouchEnded` event and was silently ignored. Confirmed against `documentation/piu/piu.md` (uses `onTouchEnded` throughout).
- **`Image.frameCount: never` → `number`** — `never` is incorrect; the native getter returns an integer (`xsIntegerValue frameCount` in `modules/piu/MC/piuMC.h`).
- **`Container.firstThat` / `lastThat`: `void` → `Content | undefined`** — both return the content whose handler returned `true`, otherwise `undefined`. Confirmed in `modules/piu/All/piuContainer.c` (`xsResult = xsVar(1)`), consistent with the docs describing traversal halting when a distributed event returns `true`.

## Verification

`tsc --noEmit --strict` passes on the edited definition file.