### PR TITLE
Fix fxGet prototypes in xs.h

### DIFF
--- a/xs/includes/xs.h
+++ b/xs/includes/xs.h
@@ -1561,9 +1561,9 @@ mxImport xsIdentifier fxToID(xsMachine*, xsSlot*);
 mxImport char* fxName(xsMachine*, xsIdentifier);
 
 mxImport void fxEnumerate(xsMachine* the);
-mxImport void fxGetAt(xsMachine*);
-mxImport void fxGetID(xsMachine*, xsIdentifier);
-mxImport void fxGetIndex(xsMachine*, xsIndex);
+mxImport xsBooleanValue fxGetAt(xsMachine*);
+mxImport xsBooleanValue fxGetID(xsMachine*, xsIdentifier);
+mxImport xsBooleanValue fxGetIndex(xsMachine*, xsIndex);
 mxImport xsBooleanValue fxHasAt(xsMachine*);
 mxImport xsBooleanValue fxHasID(xsMachine*, xsIdentifier);
 mxImport xsBooleanValue fxHasIndex(xsMachine*, xsIndex);


### PR DESCRIPTION
## Summary

This updates the public `xs.h` declarations for `fxGetAt`, `fxGetID`, and `fxGetIndex` to match their implementations and internal declarations.

## Details

Commit `5b9d4b253424e633d2c1c4ac5c6306e6cabb5cc5` changed these functions to return `txBoolean`, and updated `xsAll.h`, `xsmc.h`, and `xsmc.c` accordingly. The declarations in `xs/includes/xs.h` still returned `void`, leaving a function signature mismatch.

On the Emscripten/WASM target, this mismatch produces linker warnings such as:

```text
wasm-ld: warning: function signature mismatch: fxGetAt
wasm-ld: warning: function signature mismatch: fxGetID
wasm-ld: warning: function signature mismatch: fxGetIndex
```

In downstream testing, the generated WASM trapped at runtime. Updating the prototypes in `xs.h` removes the signature mismatch.

## Validation

- Confirmed the change is limited to `xs/includes/xs.h`.
- Built a downstream Moddable WASM app with Emscripten.
- Confirmed the `fxGetAt` / `fxGetID` / `fxGetIndex` signature mismatch warnings no longer appear.
- Confirmed the downstream WASM app starts in Chrome without the previous `RuntimeError: unreachable`.
