### PR TITLE
ESP32 419 TCP: marshal the teardown callback clear to the tcpip task

### DIFF
--- a/modules/io/socket/lwip/tcp.c
+++ b/modules/io/socket/lwip/tcp.c
@@ -239,7 +239,12 @@ void xs_tcp_destructor(void *data)
 	if (!tcp) return;
 
 	if (tcp->skt) {
-		removeTCPCallbacks(tcp);
+		// Marshaled: TCP_EVENT_RECV reads pcb->recv and pcb->callback_arg at
+		// separate instants, so clearing the callbacks from the XS task can
+		// interleave with a dispatch already in progress on the tcpip task.
+		// Running the clears on the tcpip task itself closes that window.
+		tcp_clear_callbacks_safe(tcp->skt);
+		tcp->triggerable &= ~kTCPWritable;
 
 		tcp_close_safe(tcp->skt);
 	}
@@ -256,12 +261,13 @@ void xs_tcp_destructor(void *data)
 	modInstrumentationAdjust(NetworkSockets, -1);
 }
 
+// Plain stores, so only safe when called from the tcpip task itself, where no
+// callback dispatch can be concurrent: tcpError and the tcpReceive error path.
+// XS-task teardown (doClose, xs_tcp_destructor) must use the marshaled
+// tcp_clear_callbacks_safe instead.
 void removeTCPCallbacks(TCP tcp)
 {
 	if (tcp->skt) {
-		// clear the argument first so a late callback observes NULL
-		// (the lwIP tcpip task can deliver segments - including refused-data
-		// redelivery - after the XS task tears this socket down)
 		tcp_arg(tcp->skt, NULL);
 		tcp_recv(tcp->skt, NULL);
 		tcp_sent(tcp->skt, NULL);
@@ -277,7 +283,8 @@ void doClose(xsMachine *the, xsSlot *instance)
 	if (tcp && xsmcGetHostDataValidate(*instance, (void *)&xsTCPHooks)) {
 		tcp->ready = false;
 
-		removeTCPCallbacks(tcp);
+		if (tcp->skt)
+			tcp_clear_callbacks_safe(tcp->skt);		// marshaled; see xs_tcp_destructor
 		tcp->triggerable = 0;
 
 		xsmcSetHostData(*instance, NULL);

--- a/modules/io/socket/lwip/tcp.c
+++ b/modules/io/socket/lwip/tcp.c
@@ -259,6 +259,10 @@ void xs_tcp_destructor(void *data)
 void removeTCPCallbacks(TCP tcp)
 {
 	if (tcp->skt) {
+		// clear the argument first so a late callback observes NULL
+		// (the lwIP tcpip task can deliver segments - including refused-data
+		// redelivery - after the XS task tears this socket down)
+		tcp_arg(tcp->skt, NULL);
 		tcp_recv(tcp->skt, NULL);
 		tcp_sent(tcp->skt, NULL);
 		tcp_err(tcp->skt, NULL);
@@ -355,7 +359,9 @@ void xs_tcp_read(xsMachine *the)
 			buffer->fragment = fragment->next;
 			buffer->fragmentOffset = 0;
 			if (NULL == buffer->fragment) {
+				builtinCriticalSectionBegin();
 				tcp->buffers = buffer->next;
+				builtinCriticalSectionEnd();
 				tcp_recved_safe(tcp->skt, buffer->pb->tot_len);
 				pbuf_free_safe(buffer->pb);
 				c_free(buffer);
@@ -532,6 +538,9 @@ void tcpError(void *arg, err_t err)
 {
 	TCP tcp = arg;
 
+	if (NULL == tcp)		// callbacks cleared during teardown
+		return;
+
 	removeTCPCallbacks(tcp);
 	tcp->skt = NULL;		// "pcb is already freed when this callback is called"
 	if (kTCPError & tcp->triggerable)
@@ -542,6 +551,12 @@ err_t tcpReceive(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, err_t err)
 {
 	TCP tcp = arg;
 	TCPBuffer buffer;
+
+	if (NULL == tcp) {		// callbacks cleared during teardown
+		if (pb)
+			pbuf_free(pb);
+		return ERR_OK;
+	}
 
 	if ((NULL == pb) || (ERR_OK != err)) {		//@@ when is err set here?
 		removeTCPCallbacks(tcp);
@@ -569,6 +584,10 @@ err_t tcpReceive(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, err_t err)
 
 	modInstrumentationAdjust(NetworkBytesRead, buffer->bytes);
 
+	// xs_tcp_read pops and frees head nodes on the XS task while this runs
+	// on the lwIP task; guard the pointer surgery so the tail walk cannot
+	// traverse a node being detached and freed
+	builtinCriticalSectionBegin();
 	if (tcp->buffers) {
 		TCPBuffer walker;
 
@@ -578,6 +597,7 @@ err_t tcpReceive(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, err_t err)
 	}
 	else
 		tcp->buffers = buffer;
+	builtinCriticalSectionEnd();
 
 	if (tcp->triggerable & kTCPReadable)
 		tcpTrigger(tcp, kTCPReadable);
@@ -587,6 +607,9 @@ err_t tcpReceive(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, err_t err)
 
 err_t tcpSent(void *arg, struct tcp_pcb *pcb, u16_t len)
 {
+	if (NULL == arg)		// callbacks cleared during teardown
+		return ERR_OK;
+
 	tcpTrigger((TCP)arg, kTCPWritable);
 	return ERR_OK;
 }

--- a/modules/network/socket/lwip/modLwipSafe.c
+++ b/modules/network/socket/lwip/modLwipSafe.c
@@ -119,6 +119,26 @@ void tcp_close_safe(struct tcp_pcb *tcpPCB)
 	tcpip_api_call(tcp_close_INLWIP, &msg.call);
 }
 
+static err_t tcp_clear_callbacks_INLWIP(struct tcpip_api_call_data *tcpMsg)
+{
+	LwipMsg msg = (LwipMsg)tcpMsg;
+	if (msg->tcpPCB) {
+		tcp_arg(msg->tcpPCB, NULL);
+		tcp_recv(msg->tcpPCB, NULL);
+		tcp_sent(msg->tcpPCB, NULL);
+		tcp_err(msg->tcpPCB, NULL);
+	}
+	return ERR_OK;
+}
+
+void tcp_clear_callbacks_safe(struct tcp_pcb *tcpPCB)
+{
+	LwipMsgRecord msg = {
+		.tcpPCB = tcpPCB,
+	};
+	tcpip_api_call(tcp_clear_callbacks_INLWIP, &msg.call);
+}
+
 static err_t tcp_output_INLWIP(struct tcpip_api_call_data *tcpMsg)
 {
 	LwipMsg msg = (LwipMsg)tcpMsg;

--- a/modules/network/socket/lwip/modLwipSafe.h
+++ b/modules/network/socket/lwip/modLwipSafe.h
@@ -30,6 +30,8 @@
 	#define tcp_connect_safe(skt, ipaddr, port, connected) tcp_connect(skt, ipaddr, port, connected)
 	// ESP8266 has a sort-of memory leak when using tcp_close without tcp_abort (see https://github.com/esp8266/Arduino/issues/230)
 	#define tcp_close_safe(pb) {if (CLOSED == (pb)->state) tcp_close(pb); else {tcp_close(pb); tcp_abort(pb);}}
+	// single-threaded here, so no marshaling needed
+	#define tcp_clear_callbacks_safe(pb) {tcp_arg(pb, NULL); tcp_recv(pb, NULL); tcp_sent(pb, NULL); tcp_err(pb, NULL);}
 	#define tcp_output_safe tcp_output
 	#define tcp_write_safe tcp_write
 	#define tcp_recved_safe(skt, len) tcp_recved(skt, len)
@@ -52,6 +54,7 @@
 	#include "lwip/raw.h"
 
 	struct tcp_pcb *tcp_new_safe(void);
+	void tcp_clear_callbacks_safe(struct tcp_pcb *tcpPCB);
 	err_t tcp_connect_safe(struct tcp_pcb *tcpPCB, const ip_addr_t *ipaddr, u16_t port, tcp_connected_fn connected);
 	u8_t pbuf_free_safe(struct pbuf *p);
 	err_t tcp_bind_safe(struct tcp_pcb *tcpPCB, const ip_addr_t *ipaddr, u16_t port);


### PR DESCRIPTION
Addresses the socket-teardown race in #1655, per @phoddie's `TCP_EVENT_RECV` analysis there.

lwip reads `pcb->recv` and then `pcb->callback_arg` at separate instants, so clearing the callbacks from the XS task can interleave with a dispatch already in progress on the tcpip task. This routes the XS-side teardown (`doClose`, `xs_tcp_destructor`) through a marshaled `tcp_clear_callbacks_safe`, so the clears run on the tcpip task and no callback can be in flight when it returns. `removeTCPCallbacks` stays for the callers that already run on the tcpip task (`tcpError`, the `tcpReceive` error path), where plain stores are safe. On single-threaded (`!ESP32`) builds `tcp_clear_callbacks_safe` is a plain macro.

Verified on ESP32-S3 (M5Stack CoreS3), ESP-IDF 6.0: no functional regressions and clean through heavy accept/close churn (including RST-aborted connections).

**Scope:** this is the teardown fix only, which is the part we converged on. It does **not** claim to close the separate `tcp->buffers` receive-buffer corruption still discussed in #1655 — that fault (a receive-buffer node freed under the walk, always `EXCVADDR = 0xe2f61b44`) persists even with full `builtinCriticalSection` protection of the list, so it looks like a distinct memory issue and is left open there.

CLA on file (emailed to info@moddable.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
