### PR TITLE
Fix Linux Piu wheel scrolling

### DIFF
--- a/modules/piu/PC/lin/piuView.c
+++ b/modules/piu/PC/lin/piuView.c
@@ -20,6 +20,10 @@
 
 #include "piuPC.h"
 
+#define piuWheelDelta 120
+/* GTK reports a standard Wayland wheel notch as 1.5 smooth scroll units. */
+#define piuSmoothScrollScale (piuWheelDelta / 1.5)
+
 struct _GtkPiuClip {
 	GtkFixed parent;
 	PiuContent* piuContent;
@@ -193,11 +197,17 @@ static gboolean gtk_piu_view_scroll_event(GtkWidget *widget, GdkEventScroll *eve
 {
 	gdouble delta_x = 0, delta_y = 0;
 	switch (event->direction) {
-	case GDK_SCROLL_LEFT: delta_x = 5; break;
-	case GDK_SCROLL_RIGHT: delta_x = -5; break;
-	case GDK_SCROLL_UP: delta_y = 5; break;
-	case GDK_SCROLL_DOWN: delta_y = -5; break;
-	case GDK_SCROLL_SMOOTH: gdk_event_get_scroll_deltas((GdkEvent*)event, &delta_x, &delta_y); break;
+	case GDK_SCROLL_LEFT: delta_x = piuWheelDelta; break;
+	case GDK_SCROLL_RIGHT: delta_x = -piuWheelDelta; break;
+	case GDK_SCROLL_UP: delta_y = piuWheelDelta; break;
+	case GDK_SCROLL_DOWN: delta_y = -piuWheelDelta; break;
+	case GDK_SCROLL_SMOOTH: {
+		if (gdk_event_get_scroll_deltas((GdkEvent*)event, &delta_x, &delta_y)) {
+			delta_x *= -piuSmoothScrollScale;
+			delta_y *= -piuSmoothScrollScale;
+		}
+		break;
+	}
 	}
 	if (delta_x || delta_y) {
 		GtkPiuView* gtkView = GTK_PIU_VIEW(widget);


### PR DESCRIPTION
## Summary

Fix mouse wheel scrolling in Linux Piu applications.

Linux GTK scroll events produced scrolling that was both reversed and much smaller than on other platforms. This change normalizes the direction and amount to match the behavior of the Windows and other Piu backends.

## Testing

- Built `xsbug` for `x-lin`.
- Built `mcsim` for `x-lin`.
- Verified wheel scrolling direction and speed in `xsbug` on Sway/Wayland.
