### PR TITLE
lwIP: avoid stale PCB use after remote close

### DIFF
--- a/modules/io/socket/lwip/tcp.c
+++ b/modules/io/socket/lwip/tcp.c
@@ -369,7 +369,7 @@ void xs_tcp_read(xsMachine *the)
 				builtinCriticalSectionBegin();
 				tcp->buffers = buffer->next;
 				builtinCriticalSectionEnd();
-				tcp_recved_safe(tcp->skt, buffer->pb->tot_len);
+				tcp_recved_safe(&tcp->skt, buffer->pb->tot_len);
 				pbuf_free_safe(buffer->pb);
 				c_free(buffer);
 				if (NULL == tcp->buffers) {
@@ -566,10 +566,9 @@ err_t tcpReceive(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, err_t err)
 	}
 
 	if ((NULL == pb) || (ERR_OK != err)) {		//@@ when is err set here?
-		removeTCPCallbacks(tcp);
-#if ESP32
-//@@		tcp->skt = NULL;			// no close on socket if disconnected.
-#endif
+		tcp_recv(pcb, NULL);
+		tcp_sent(pcb, NULL);
+		tcp->triggerable &= ~kTCPWritable;
 		tcpTrigger(tcp, kTCPError);
 		return ERR_OK;
 	}

--- a/modules/network/socket/lwip/modLwipSafe.c
+++ b/modules/network/socket/lwip/modLwipSafe.c
@@ -29,6 +29,7 @@ typedef struct {
 
 	err_t						err;
 	struct tcp_pcb				*tcpPCB;
+	struct tcp_pcb				**tcpPCBRef;
 	struct udp_pcb				*udpPCB;
 	ip_addr_t					*ipaddr;
 	ip_addr_t					addr;
@@ -174,19 +175,23 @@ err_t tcp_write_safe(struct tcp_pcb *tcpPCB, const void *data, u16_t len, u8_t f
 	return msg.err;
 }
 
-static void tcp_recved_INLWIP(void *ctx)
+static err_t tcp_recved_INLWIP(struct tcpip_api_call_data *tcpMsg)
 {
-	LwipMsg msg = (LwipMsg)ctx;
-	tcp_recved(msg->tcpPCB, msg->len);
-	c_free(msg);
+	LwipMsg msg = (LwipMsg)tcpMsg;
+	if (*msg->tcpPCBRef)
+		tcp_recved(*msg->tcpPCBRef, msg->len);
+	return ERR_OK;
 }
 
-void tcp_recved_safe(struct tcp_pcb *tcpPCB, u16_t len)
+void tcp_recved_safe(struct tcp_pcb **tcpPCBRef, u16_t len)
 {
-	LwipMsg msg = c_malloc(sizeof(LwipMsgRecord));
-	msg->tcpPCB = tcpPCB;
-	msg->len = len;
-	tcpip_callback_with_block(tcp_recved_INLWIP, msg, 1);
+	LwipMsgRecord msg = {
+		.tcpPCBRef = tcpPCBRef,
+		.len = len,
+	};
+	// Re-read the PCB after earlier queued network events have run. The owner
+	// stays alive because tcpip_api_call does not return until this completes.
+	tcpip_api_call(tcp_recved_INLWIP, &msg.call);
 }
 
 static err_t tcp_listen_INLWIP(struct tcpip_api_call_data *tcpMsg)
@@ -294,4 +299,3 @@ err_t dns_gethostbyname_safe(const char *hostname, ip_addr_t *addr, dns_found_ca
 }
 
 #endif
-

--- a/modules/network/socket/lwip/modLwipSafe.h
+++ b/modules/network/socket/lwip/modLwipSafe.h
@@ -34,7 +34,7 @@
 	#define tcp_clear_callbacks_safe(pb) {tcp_arg(pb, NULL); tcp_recv(pb, NULL); tcp_sent(pb, NULL); tcp_err(pb, NULL);}
 	#define tcp_output_safe tcp_output
 	#define tcp_write_safe tcp_write
-	#define tcp_recved_safe(skt, len) tcp_recved(skt, len)
+	#define tcp_recved_safe(skt, len) {if (*(skt)) tcp_recved(*(skt), len);}
 	#define udp_new_safe udp_new
 	#define udp_bind_safe udp_bind
 	#define udp_remove_safe udp_remove
@@ -61,7 +61,7 @@
 	void tcp_close_safe(struct tcp_pcb *tcpPCB);
 	void tcp_output_safe(struct tcp_pcb *tcpPCB);
 	err_t tcp_write_safe(struct tcp_pcb *tcpPCB, const void *data, u16_t len, u8_t flags);
-	void tcp_recved_safe(struct tcp_pcb *tcpPCB, u16_t len);
+	void tcp_recved_safe(struct tcp_pcb **tcpPCBRef, u16_t len);
 	struct tcp_pcb * tcp_listen_safe(struct tcp_pcb *pcb);
 	struct udp_pcb *udp_new_safe(void);
 	err_t udp_bind_safe(struct udp_pcb *udpPCB, const ip_addr_t *ipaddr, u16_t port);

--- a/modules/network/socket/lwip/modSocket.c
+++ b/modules/network/socket/lwip/modSocket.c
@@ -586,7 +586,7 @@ void xs_socket_read(xsMachine *the)
 			socketSetPending(xss, kPendingReceive);
 		else {
 			if ((kTCP == xss->kind) && xss->skt)
-				tcp_recved_safe(xss->skt, xss->pb->tot_len);
+				tcp_recved_safe(&xss->skt, xss->pb->tot_len);
 
 			pbuf_free_safe(xss->pb);
 			xss->pb = NULL;
@@ -860,7 +860,7 @@ void socketMsgDataReceived(xsSocket xss)
 		}
 
 		if ((kTCP == xss->kind) && xss->skt)	//@@
-			tcp_recved_safe(xss->skt, xss->pb->tot_len);
+			tcp_recved_safe(&xss->skt, xss->pb->tot_len);
 
 		pbuf_free_safe(xss->pb);
 		xss->pb = NULL;
@@ -1010,7 +1010,6 @@ err_t didReceive(void * arg, struct tcp_pcb * pcb, struct pbuf * p, err_t err)
 	if (!p) {		// connnection closed
 		tcp_recv(xss->skt, NULL);
 		tcp_sent(xss->skt, NULL);
-		tcp_err(xss->skt, NULL);
 
 		if (xss->reader[0] || xss->buflen)
 			xss->disconnectedWhileReading = true;
@@ -1364,4 +1363,3 @@ void *modSocketGetLWIP(xsMachine *the, xsSlot *slot)
 	}
 	return skt;
 }
-


### PR DESCRIPTION
## Summary

Prevent a delayed receive-window notification from calling `tcp_recved()` with a freed lwIP `tcp_pcb` after the remote peer closes a connection while received data remains buffered.

## Root cause

When `tcpReceive()` receives a terminal notification (`pb == NULL` or a receive error), it currently clears the receive, sent, and error callbacks. Buffered data may still be owned by the socket and consumed later from the XS task.

When that data is consumed, `tcp_recved_safe()` stores the current raw `tcp_pcb *` in a heap-allocated message and posts it with `tcpip_callback_with_block()`. The `block` argument only blocks until the message can be posted; it does not wait for the callback to run.

The PCB can therefore be destroyed before `tcp_recved_INLWIP()` executes. Because the terminal receive path already removed `tcp_err`, `tcpError()` cannot clear the owner's socket pointer. The queued callback then calls `tcp_recved()` with a stale PCB.

The observed ESP32-S3 panic ended in:

```text
tcp_update_rcv_ann_wnd
tcp_recved
tcp_recved_INLWIP
tcpip_thread_handle_msg
tcpip_thread
```

GDB showed that the PCB contents had already been overwritten and that it was no longer present in lwIP's active PCB lists, while the socket owner still retained the old pointer.

## Changes

- On terminal receive, disable the receive and sent callbacks but retain the error callback and callback argument until final teardown.
- Change `tcp_recved_safe()` to receive a pointer to the owner's PCB pointer.
- Use synchronous `tcpip_api_call()` and re-read that pointer after earlier queued lwIP work has run.
- Skip `tcp_recved()` if `tcpError()` has already invalidated the owner's pointer.
- Update both the ECMA-419 `io/socket` implementation and the legacy `network/socket` implementation.

The synchronous call also removes the heap allocation and deferred callback previously used by `tcp_recved_safe()`.

## Relationship to #1655 and #1656

PR #1656 prevents local XS-side socket teardown from racing an lwIP callback that is already being dispatched.

This change addresses a different lifetime direction: after a remote close, an XS-side receive notification can retain a PCB that is destroyed before the queued notification executes.

This PR does not attempt to resolve the separate `tcp->buffers` node corruption still discussed in #1655.

## Validation

Tested on an M5Stack CoreS3 with Moddable 9.0.0 and ESP-IDF 6.0.2.

The reproducer streams data to the device and closes the server side immediately after the response, leaving unread socket buffers. The unpatched build reproduced the `tcp_recved()` panic and reboot.

With this change:

- One real-time-paced fixture run terminated normally.
- Three unpaced, higher-load fixture runs terminated normally.
- No `tcp_recved()` panic, task deadlock, or device reboot was observed.
- The complete CoreS3 application builds successfully.

No automated test is included because the failure depends on the ESP32 lwIP tcpip task and native PCB destruction order; a JavaScript fake socket does not exercise that lifetime.