### PR TITLE
CoreS3: keep I2S speaker and microphone half-duplex

### DIFF
--- a/build/devices/esp32/targets/m5stack_cores3/M5StackCoreS3AudioIn.js
+++ b/build/devices/esp32/targets/m5stack_cores3/M5StackCoreS3AudioIn.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Shinya Ishikawa
+ * Copyright (c) 2026 Shinya Ishikawa
  *
  *   This file is part of the Moddable SDK Runtime.
  *
@@ -18,35 +18,29 @@
  *
  */
 
-import AudioOut from "embedded:io/audio/out-original";
+import AudioIn from "embedded:io/audio/in-original";
 import { acquireI2S, releaseI2S } from "M5StackCoreS3I2SBus";
 
-/**
- * A special AudioOut implementation for M5Stack CoreS3
- * CoreS3 has an amplifier IC (AW88298).
- * The user must set the sample rate to the IC before playing audio.
- */
-export default class M5StackCoreS3AudioOut extends AudioOut {
+export default class M5StackCoreS3AudioIn extends AudioIn {
   constructor(options) {
-    acquireI2S("speaker", options && options.sampleRate);
+    acquireI2S("microphone", options && options.sampleRate);
     try {
       super(options);
     }
     catch (error) {
-      releaseI2S("speaker");
+      releaseI2S("microphone");
       throw error;
     }
-    acquireI2S("speaker", this.sampleRate);
   }
 
   start() {
-    acquireI2S("speaker", this.sampleRate);
+    acquireI2S("microphone", this.sampleRate);
     return super.start();
   }
 
   stop() {
     const result = super.stop();
-    releaseI2S("speaker");
+    releaseI2S("microphone");
     return result;
   }
 
@@ -55,7 +49,7 @@ export default class M5StackCoreS3AudioOut extends AudioOut {
       return super.close();
     }
     finally {
-      releaseI2S("speaker");
+      releaseI2S("microphone");
     }
   }
 }

--- a/build/devices/esp32/targets/m5stack_cores3/M5StackCoreS3I2SBus.js
+++ b/build/devices/esp32/targets/m5stack_cores3/M5StackCoreS3I2SBus.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Shinya Ishikawa
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+let owner = "";
+
+export function acquireI2S(role, sampleRate) {
+	if (owner && (owner !== role))
+		releaseI2S(owner);
+	if (role === "speaker") {
+		if (globalThis.amp && globalThis.amp.start)
+			globalThis.amp.start(sampleRate);
+	}
+	else if (globalThis.mic && globalThis.mic.start)
+		globalThis.mic.start(sampleRate);
+	owner = role;
+}
+
+export function releaseI2S(role) {
+	if (owner !== role)
+		return;
+	if (role === "speaker") {
+		if (globalThis.amp && globalThis.amp.stop)
+			globalThis.amp.stop();
+	}
+	else if (globalThis.mic && globalThis.mic.stop)
+		globalThis.mic.stop();
+	owner = "";
+}

--- a/build/devices/esp32/targets/m5stack_cores3/manifest.json
+++ b/build/devices/esp32/targets/m5stack_cores3/manifest.json
@@ -10,6 +10,7 @@
 	"include": [
 		"$(MODDABLE)/modules/io/manifest.json",
 		"$(MODDABLE)/modules/io/audioout/manifest.json",
+		"$(MODDABLE)/modules/io/audioin/manifest.json",
 		"$(MODDABLE)/modules/drivers/ili9341/manifest.json",
 		"$(MODDABLE)/modules/drivers/sensors/ft6206/manifest_async.json",
 		"$(MODDABLE)/modules/drivers/sensors/bmi270/manifest.json",
@@ -31,6 +32,9 @@
 		"setup/target": "./setup-target",
 		"embedded:io/audio/out-original": "$(MODULES)/io/audioout/esp32/*",
 		"embedded:io/audio/out": "./M5StackCoreS3AudioOut",
+		"embedded:io/audio/in-original": "$(MODULES)/io/audioin/esp32/audioin",
+		"embedded:io/audio/in": "./M5StackCoreS3AudioIn",
+		"M5StackCoreS3I2SBus": "./M5StackCoreS3I2SBus",
 		"*": [
 			"./M5StackCoreS3Touch"
 		]
@@ -108,10 +112,10 @@
 			"i2s": {
 				"num": 1,
 				"slot": "I2S_STD_SLOT_LEFT",
+				"format_i2s": 1,
 				"bitsPerSample": 16,
 				"bck_pin": 34,
 				"lr_pin": 33,
-				"mck_pin": 0,
 				"dataout_pin": 13
 			}
 		},

--- a/build/devices/esp32/targets/m5stack_cores3/setup-target.js
+++ b/build/devices/esp32/targets/m5stack_cores3/setup-target.js
@@ -136,6 +136,16 @@ class AW88298 {
     this.sampleRate = 24000;
   }
 
+  start(sampleRate) {
+    if (sampleRate)
+      this.sampleRate = sampleRate;
+    this.#io.writeUint16(0x04, 0x4040, true); // I2SEN=1 AMPPD=0 PWDN=0
+  }
+
+  stop() {
+    this.#io.writeUint16(0x04, 0x0040, true); // I2SEN=0
+  }
+
   /**
    * @note with ESP-IDF, 11025Hz and its multiples are not available for the slight gap between the clock of ESP32S3 and AW88298 PLL
    * @fixme should reset sampleRate if the different value specified in AudioOut#constructor
@@ -217,6 +227,14 @@ class ES7210 {
     for (const [reg, value] of data) {
       io.writeUint8(reg, value);
     }
+  }
+
+  start() {
+    this.init();
+  }
+
+  stop() {
+    this.#io.writeUint8(0x00, 0xFF); // RESET_CTL
   }
 }
 

--- a/modules/io/audioin/esp32/audioin.c
+++ b/modules/io/audioin/esp32/audioin.c
@@ -88,6 +88,7 @@
 #define AUDIO_IN_TIMEOUT	50
 #define MAX_INPUT_BLOCK		2048
 #define AUDIO_IN_BUFFERSIZE	(8192 * 2)
+#define AUDIO_IN_DMA_FRAMES	240
 
 enum {
 	kStateIdle = 0,
@@ -120,6 +121,7 @@ struct AudioInputRecord {
 	uint8_t		*playPos;
 	uint8_t		*endPos;
 	uint32_t	bufferSize;
+	uint32_t	dmaReadBytes;
 	uint8_t		buffer[];
 };
 typedef struct AudioInputRecord AudioInputRecord;
@@ -168,6 +170,63 @@ static int amtReadable(AudioInput input) {
 		p += input->bufferSize;
 	return p;
 }
+
+#if !MODDEF_AUDIOIN_I2S_ADC && !MODDEF_AUDIOIN_I2S_PDM
+static void audioInCloseChannel(AudioInput input)
+{
+	if (!input->handle)
+		return;
+	if (ESP_OK == i2s_del_channel(input->handle))
+		input->handle = C_NULL;
+}
+
+static esp_err_t audioInOpenStdChannel(AudioInput input)
+{
+	esp_err_t err;
+	i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(MODDEF_AUDIOIN_I2S_NUM, I2S_ROLE_MASTER);
+	i2s_std_config_t rx_std_cfg = {
+		.clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(input->sampleRate),
+#if MODDEF_AUDIOIN_I2S_FORMAT_I2S
+		.slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT,
+			(2 == MODDEF_AUDIOIN_NUMCHANNELS) ? I2S_SLOT_MODE_STEREO : I2S_SLOT_MODE_MONO),
+#else
+		.slot_cfg = I2S_STD_MSB_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT,
+			(2 == MODDEF_AUDIOIN_NUMCHANNELS) ? I2S_SLOT_MODE_STEREO : I2S_SLOT_MODE_MONO),
+#endif
+		.gpio_cfg = {
+			.mclk = MODDEF_AUDIOIN_I2S_MCK_PIN,
+			.bclk = MODDEF_AUDIOIN_I2S_BCK_PIN,
+			.ws = MODDEF_AUDIOIN_I2S_LR_PIN,
+			.dout = I2S_GPIO_UNUSED,
+			.din = MODDEF_AUDIOIN_I2S_DATAIN,
+			.invert_flags = {
+				.mclk_inv = false,
+				.bclk_inv = false,
+				.ws_inv = false,
+			}
+		}
+	};
+
+	chan_cfg.dma_desc_num = 6;
+	chan_cfg.dma_frame_num = AUDIO_IN_DMA_FRAMES;
+	input->handle = C_NULL;
+	err = i2s_new_channel(&chan_cfg, C_NULL, &input->handle);
+	if (ESP_OK != err) {
+		input->handle = C_NULL;
+		return err;
+	}
+
+	rx_std_cfg.slot_cfg.slot_mask = (2 == MODDEF_AUDIOIN_NUMCHANNELS)
+		? I2S_STD_SLOT_BOTH
+		: MODDEF_AUDIOIN_I2S_SLOT;
+	err = i2s_channel_init_std_mode(input->handle, &rx_std_cfg);
+	if (ESP_OK != err) {
+		audioInCloseChannel(input);
+		return err;
+	}
+	return ESP_OK;
+}
+#endif
 
 void xs_audioin_constructor(xsMachine *the)
 {
@@ -249,8 +308,40 @@ void xs_audioin_constructor(xsMachine *the)
 	gPDMAudioInBusy = 1;
 #endif
 
+	input->dmaReadBytes = AUDIO_IN_DMA_FRAMES * ((1 == numChannels) ? 4 : bytesPerFrame);
+
+#if !MODDEF_AUDIOIN_I2S_ADC && !MODDEF_AUDIOIN_I2S_PDM
+	{
+		esp_err_t err = audioInOpenStdChannel(input);
+		if (ESP_OK != err) {
+			xsForget(input->object);
+			c_free(input);
+			xsmcSetHostData(xsThis, C_NULL);
+			xsUnknownError("I2S input setup failed");
+		}
+	}
+#endif
+
 	input->mutex = xSemaphoreCreateMutex();
-	xTaskCreate(audioInLoop, "audioInput", 4096 + 1024, input, 10, &input->task);
+	if (!input->mutex) {
+#if !MODDEF_AUDIOIN_I2S_ADC && !MODDEF_AUDIOIN_I2S_PDM
+		audioInCloseChannel(input);
+#endif
+		xsForget(input->object);
+		c_free(input);
+		xsmcSetHostData(xsThis, C_NULL);
+		xsUnknownError("no memory for AudioIn mutex");
+	}
+	if (pdPASS != xTaskCreate(audioInLoop, "audioInput", 4096 + 1024, input, 10, &input->task)) {
+#if !MODDEF_AUDIOIN_I2S_ADC && !MODDEF_AUDIOIN_I2S_PDM
+		audioInCloseChannel(input);
+#endif
+		vSemaphoreDelete(input->mutex);
+		xsForget(input->object);
+		c_free(input);
+		xsmcSetHostData(xsThis, C_NULL);
+		xsUnknownError("AudioIn task create failed");
+	}
 }
 
 void xs_audioin_destructor(void *it)
@@ -459,6 +550,9 @@ void audioInLoop(void *pvParameter)
 	AudioInput input = pvParameter;
 	uint8_t stopped = true, enabled = false;
 
+	if (input->handle)
+		goto ready;
+
 // ### HW CONFIGURATION
 #if MODDEF_AUDIOIN_I2S_ADC
 #error untested
@@ -546,25 +640,23 @@ void audioInLoop(void *pvParameter)
 
 	err = i2s_channel_init_std_mode(input->handle, &rx_std_cfg);
 	if (err) {
-		i2s_del_channel(input->handle);
+		if (ESP_OK == i2s_del_channel(input->handle))
+			input->handle = C_NULL;
 		modLog("i2s_channel_init failed");
 	}
 #endif
 
-	err = i2s_channel_enable(input->handle);
-	if (err) {
-		i2s_del_channel(input->handle);
-		input->handle = C_NULL;
-		modLog("i2s_channel_enable failed");
-	}
-	enabled = true;
+	/* Leave the RX channel in READY until start(). Enabling here drives BCLK/WS
+	 * while the application still considers the microphone idle. */
+	enabled = false;
 #endif
 
+ready:
 	if (C_NULL == input->handle)
 		goto done;
 
 	while (true) {
-		size_t bytes_read;
+		size_t bytes_read = 0;
 
 		if (kStateRecording != input->state) {
 			uint32_t newState;
@@ -659,14 +751,21 @@ void audioInLoop(void *pvParameter)
 			input->recPos = input->buffer;
 		}
 		xSemaphoreGive(input->mutex);
+		if (input->dmaReadBytes && (amt > input->dmaReadBytes))
+			amt = input->dmaReadBytes;
 		amt = (amt > MAX_INPUT_BLOCK) ? MAX_INPUT_BLOCK : amt;
+		if (input->dmaReadBytes)
+			amt -= (amt % input->dmaReadBytes);
 		if (amt > 0) {
 			err = i2s_channel_read(input->handle, input->recPos, amt, &bytes_read, AUDIO_IN_TIMEOUT);
-			if (bytes_read) {
-				xSemaphoreTake(input->mutex, portMAX_DELAY);
-				input->recPos += bytes_read;
-				xSemaphoreGive(input->mutex);
-			}
+			if (ESP_ERR_TIMEOUT == err)
+				continue;
+			if ((ESP_OK != err) || (0 == bytes_read) ||
+				(input->dmaReadBytes && (bytes_read % input->dmaReadBytes)))
+				continue;
+			xSemaphoreTake(input->mutex, portMAX_DELAY);
+			input->recPos += bytes_read;
+			xSemaphoreGive(input->mutex);
 		}
 #endif
 
@@ -682,12 +781,14 @@ void audioInLoop(void *pvParameter)
 
 	// ## HW shutdown
 	if (input->handle) {
-#if MODDEF_AUDIOOUT_I2S_ADC
+#if MODDEF_AUDIOIN_I2S_ADC
 		adc_continuous_deinit(input->handle);
+		input->handle = C_NULL;
 #else
 		if (enabled)
 			i2s_channel_disable(input->handle);
-		i2s_del_channel(input->handle);
+		if (ESP_OK == i2s_del_channel(input->handle))
+			input->handle = C_NULL;
 #endif
 	}
 

--- a/modules/io/audioout/esp32/audioout-esp32.c
+++ b/modules/io/audioout/esp32/audioout-esp32.c
@@ -32,6 +32,10 @@
 	#include "modGPIO.h"
 #endif
 
+#ifndef MODDEF_AUDIOOUT_I2S_NUM
+	#define MODDEF_AUDIOOUT_I2S_NUM I2S_NUM_AUTO
+#endif
+
 #ifndef MODDEF_AUDIOOUT_I2S_SLOT
 	#define MODDEF_AUDIOOUT_I2S_SLOT I2S_STD_SLOT_RIGHT
 #endif
@@ -227,7 +231,7 @@ void xs_audioout_constructor_(xsMachine *the)
 	xsSetHostHooks(xsThis, (xsHostHooks *)&xsAudioOutHooks);
 	xsRemember(audioOut->obj);
 
-    i2s_chan_config_t tx_chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_AUTO, I2S_ROLE_MASTER);
+    i2s_chan_config_t tx_chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(MODDEF_AUDIOOUT_I2S_NUM, I2S_ROLE_MASTER);
     tx_chan_cfg.auto_clear = true;
 
 	// number of DMA buffers and their size in samples (default is 6 and 240)
@@ -277,40 +281,51 @@ void xs_audioout_constructor_(xsMachine *the)
 	i2s_config.clk_cfg.clk_src = I2S_CLK_SRC_DEFAULT;
 	i2s_config.clk_cfg.mclk_multiple = I2S_MCLK_MULTIPLE_256;
 
-	// I2S_STD_MSB_SLOT_DEFAULT_CONFIG(bitwidth, mode) (i2s_std.h)
-	int msb_right = true;
 #if MODDEF_AUDIOOUT_I2S_BITSPERSAMPLE == 32
 	i2s_config.slot_cfg.data_bit_width = I2S_DATA_BIT_WIDTH_16BIT;
 	i2s_config.slot_cfg.ws_width = I2S_DATA_BIT_WIDTH_32BIT;
-	msb_right = false;
-#elif MODDEF_AUDIOOUT_I2S_BITSPERSAMPLE == 16
-	i2s_config.slot_cfg.data_bit_width = I2S_DATA_BIT_WIDTH_16BIT;
-	i2s_config.slot_cfg.ws_width = I2S_DATA_BIT_WIDTH_16BIT;
-#else
-	i2s_config.slot_cfg.data_bit_width = I2S_DATA_BIT_WIDTH_8BIT;
-	i2s_config.slot_cfg.ws_width = I2S_DATA_BIT_WIDTH_8BIT;
-#endif
 	i2s_config.slot_cfg.slot_bit_width = I2S_SLOT_BIT_WIDTH_AUTO;
+	i2s_config.slot_cfg.ws_pol = false;
 #if SOC_I2S_HW_VERSION_1	// esp32/s2
-	i2s_config.slot_cfg.msb_right = msb_right;
+	i2s_config.slot_cfg.msb_right = false;
 #else
 	i2s_config.slot_cfg.left_align = false;
 	i2s_config.slot_cfg.big_endian = false;
 	i2s_config.slot_cfg.bit_order_lsb = false;
 #endif
-
-#if MODDEF_AUDIOOUT_NUMCHANNELS == 2
-	i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_STEREO;
-	i2s_config.slot_cfg.slot_mask = I2S_SLOT_MODE_BOTH;
-#else
-	i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_MONO;
-	i2s_config.slot_cfg.slot_mask = MODDEF_AUDIOOUT_I2S_SLOT;
-#endif
-	i2s_config.slot_cfg.ws_pol = false;
 #if MODDEF_AUDIOOUT_I2S_FORMAT_I2S
 	i2s_config.slot_cfg.bit_shift = true;
 #else
 	i2s_config.slot_cfg.bit_shift = false;
+#endif
+#if MODDEF_AUDIOOUT_NUMCHANNELS == 2
+	i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_STEREO;
+	i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+#else
+	i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_MONO;
+	i2s_config.slot_cfg.slot_mask = MODDEF_AUDIOOUT_I2S_SLOT;
+#endif
+#else
+	{
+		const i2s_data_bit_width_t width =
+#if MODDEF_AUDIOOUT_I2S_BITSPERSAMPLE == 16
+			I2S_DATA_BIT_WIDTH_16BIT;
+#else
+			I2S_DATA_BIT_WIDTH_8BIT;
+#endif
+		const i2s_slot_mode_t mode =
+			(2 == MODDEF_AUDIOOUT_NUMCHANNELS) ? I2S_SLOT_MODE_STEREO : I2S_SLOT_MODE_MONO;
+#if MODDEF_AUDIOOUT_I2S_FORMAT_I2S
+		i2s_config.slot_cfg = (i2s_std_slot_config_t)I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(width, mode);
+#else
+		i2s_config.slot_cfg = (i2s_std_slot_config_t)I2S_STD_MSB_SLOT_DEFAULT_CONFIG(width, mode);
+#endif
+#if MODDEF_AUDIOOUT_NUMCHANNELS == 2
+		i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+#else
+		i2s_config.slot_cfg.slot_mask = MODDEF_AUDIOOUT_I2S_SLOT;
+#endif
+	}
 #endif
 
 


### PR DESCRIPTION
## Summary

Keep the M5Stack CoreS3 speaker and microphone half-duplex on a single I2S bus. AudioOut now uses the manifest I2S port, no longer drives ES7210's MCLK, and AudioIn no longer enables RX before `start()`.

## Problem

CoreS3 shares BCLK/WS between AW88298 and ES7210. GPIO0 MCLK is wired only to ES7210.

The generic ESP32 AudioOut constructor always called `I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_AUTO, ...)`, so it ignored `audioOut.i2s.num`. AudioIn enabled the RX channel as soon as the worker task started, even while the application still considered the microphone idle. CoreS3 also configured AudioOut with `mck_pin: 0`.

Together, a 24 kHz speaker turn can leave the shared clock and codec in a state that corrupts the next 16 kHz microphone turn.

## Changes

- `audioout-esp32.c`: use `MODDEF_AUDIOOUT_I2S_NUM` (default `I2S_NUM_AUTO`) and IDF Philips/MSB slot macros.
- CoreS3 `audioOut.i2s`: keep I2S1, add `format_i2s: 1`, remove speaker `mck_pin`.
- `audioin.c`: create the standard RX channel in READY from the constructor, enable it only after `start()`, initialize `bytes_read`, and ignore timeout/unaligned reads.
- CoreS3 wrappers take a single bus owner and call `amp.start`/`amp.stop` and `mic.start`/`mic.stop` when the half-duplex role changes.

This does not add a shared TX/RX duplex controller. 16 kHz capture and 24 kHz playback still alternate.

## Validation

- The constructor-time AudioIn setup and AudioOut I2S port selection were reviewed against the ESP-IDF standard I2S APIs.
- A CoreS3 firmware build/flash cycle was **not** run in this environment.

## Notes

Projects that remap `embedded:io/audio/in` back to the generic ESP32 module will still get the C-level READY/`start()` change, but not the CoreS3 codec owner.