### PR TITLE
Align HTTP request write typings with ECMA-419

### DIFF
--- a/typings/embedded_network/http/client.d.ts
+++ b/typings/embedded_network/http/client.d.ts
@@ -41,7 +41,8 @@ declare module "embedded:network/http/client" {
   export interface HTTPRequest {
     read(byteLength?: number): ArrayBuffer|undefined;
     read(buffer: ByteBuffer): void;
-    write(value: ByteBuffer|undefined): void;
+    write(): number;
+    write(value: ByteBuffer|undefined): number;
   }
 
   class HTTPClient {


### PR DESCRIPTION
ECMA-419 specifies that calling write() with no arguments signals the end of a request body using chunked transfer encoding. It also specifies that write() returns the number of bytes that may subsequently be written.