### PR TITLE
Fix SMBus constructor options type

### DIFF
--- a/typings/embedded_io/smbus.d.ts
+++ b/typings/embedded_io/smbus.d.ts
@@ -22,7 +22,7 @@ declare module "embedded:io/smbus" {
   import I2C from "embedded:io/i2c"
 
   class SMBus extends I2C {
-    constructor(options: ConstructorParameters<typeof I2C> & {
+    constructor(options: ConstructorParameters<typeof I2C>[0] & {
       stop?: boolean;
     });
     readUint8(register: number): number;


### PR DESCRIPTION
Fix the SMBus constructor type declaration to use the first parameter of the I2C constructor.

ConstructorParameters<typeof I2C> produces a tuple containing the constructor arguments. Intersecting that tuple directly with the SMBus-specific options caused TypeScript to reject valid I2C properties such as address, data, clock, and hz.

Selecting the first tuple element with ConstructorParameters<typeof I2C>[0] correctly extends the I2C options with the optional SMBus stop property.