### PR TITLE
Update expander.js 0x06 should be 0x0C for pullups

### DIFF
--- a/modules/io/expander/expander.js
+++ b/modules/io/expander/expander.js
@@ -65,7 +65,7 @@ class Expander {
 		i2c.write(0x00, 0b11111111, 0b11111111);
 
 		i2c.pullups = 0b0000000000000000;		// set bit to indicate pin is pulled up
-		i2c.write(0x06, 0b00000000, 0b00000000);
+		i2c.write(0x0C, 0b00000000, 0b00000000); // GPPU
 
 		i2c.output = 0b0000000000000000;		// each bit represents the last set value of an output
 		i2c.write(0x12, 0b00000000, 0b00000000);
@@ -190,7 +190,7 @@ class InputBank extends IO {
 		this.#i2c = i2c;
 
 		i2c.pullups = (Digital.InputPullUp === options.mode) ? (i2c.pullups | pins) : (i2c.pullups & ~pins);
-		i2c.write(0x06, i2c.pullups & 255, i2c.pullups >> 8);
+		i2c.write(0x0C, i2c.pullups & 255, i2c.pullups >> 8); // GPPU
 
 		i2c.inputs |= pins;
 		i2c.write(0x00, i2c.inputs & 255, i2c.inputs >> 8);


### PR DESCRIPTION
I believe in both places it should be `0x0C` (as `0x06` is DEFVAL).

It works either way with my mcp23017 for interrupts on buttons. Might be why it wasn't noticed.

Still new to this chip so could be reading the library wrong.