### PR TITLE
Fix listen query forwarding and URL searchParams synchronization

### DIFF
--- a/examples/io/listener/listen/listen.js
+++ b/examples/io/listener/listen/listen.js
@@ -152,7 +152,9 @@ async function* listen(options) {
 					_connection_.accept({
 						onRequest(_request_) {
 							const { method, path, headers } = _request_;
-							const request = new Request(new URL(path, base), { method, path, headers, body:requestPromise });
+							const url = new URL(path, base);
+							url.search = _request_.query;
+							const request = new Request(url, { method, path, headers, body:requestPromise });
 							const connection = {
 								close() {
 									_connection_.close();

--- a/modules/data/url/url.js
+++ b/modules/data/url/url.js
@@ -44,7 +44,7 @@ class URL {
 			this.#parts = parseURL(href, parseURL(base));
 		else
 			this.#parts = parseURL(href);
-		this.#searchParams = new URLSearchParams(this.#parts.query, this.#parts);
+		this.#searchParams = new URLSearchParams(this.#parts.query ?? "", this.#parts);
 	}
 	get hash() {
 		return serializeURL(this.#parts, FRAGMENT);
@@ -69,7 +69,7 @@ class URL {
 	}
 	set href(it) {
 		this.#parts = parseURL(it);
-		this.#searchParams.updatePairs();
+		this.#searchParams.updatePairs(this.#parts);
 	}
 	get origin() {
 		return serializeURL(this.#parts, ORIGIN);
@@ -180,9 +180,10 @@ class URLSearchParams {
 	toString() {
 		return serializeQuery(this.#pairs);
 	}
-	updatePairs() {
-		if (this.#parts)
-			this.#pairs = parseQuery(this.#parts.query);
+	updatePairs(parts = this.#parts) {
+		this.#parts = parts;
+		if (parts)
+			this.#pairs = parseQuery(parts.query ?? "");
 	}
 	updateParts() {
 		if (this.#parts)


### PR DESCRIPTION
Title: Fix query parameters in listen and URL searchParams synchronization

Fixes #1692.

Preserve query parameters when constructing request URLs in `listen`. Fix `URL.searchParams` synchronization when setting `search` on a URL without a query or replacing `href`, while preserving the existing `searchParams` object.