### PR TITLE
Listener construct failure on lin/mac omits xsForget

### DIFF
--- a/modules/io/socket/lin/tcp.c
+++ b/modules/io/socket/lin/tcp.c
@@ -558,7 +558,7 @@ static const xsHostHooks xsListenerHooks = {
 
 void xs_listener_constructor(xsMachine *the)
 {
-	Listener listener;
+	Listener listener = C_NULL;
 	int port = 0;
 	xsSlot *onReadable;
 
@@ -580,6 +580,8 @@ void xs_listener_constructor(xsMachine *the)
 		struct sockaddr_in address = { 0 };
 
 		listener = c_calloc(sizeof(ListenerRecord), 1);
+		if (!listener)
+			xsUnknownError("no memory");
 		listener->the = the;
 		listener->obj = xsThis;
 		xsmcSetHostData(xsThis, listener);
@@ -610,8 +612,11 @@ void xs_listener_constructor(xsMachine *the)
 		xsSetHostHooks(xsThis, (xsHostHooks *)&xsListenerHooks);
 	}
 	xsCatch {
-		xsmcSetHostData(xsThis, NULL);
-		xs_listener_destructor_(listener);
+		if (listener) {
+			xsForget(listener->obj);
+			xsmcSetHostData(xsThis, NULL);
+			xs_listener_destructor_(listener);
+		}
 		xsThrow(xsException);
 	}
 }

--- a/modules/io/socket/mac/tcp.m
+++ b/modules/io/socket/mac/tcp.m
@@ -618,7 +618,7 @@ static const xsHostHooks xsListenerHooks = {
 
 void xs_listener_constructor(xsMachine *the)
 {
-	Listener listener;
+	Listener listener = C_NULL;
 	int port = 0;
 	xsSlot *onReadable;
 
@@ -678,8 +678,11 @@ void xs_listener_constructor(xsMachine *the)
 		xsSetHostHooks(xsThis, (xsHostHooks *)&xsListenerHooks);
 	}
 	xsCatch {
-		xsmcSetHostData(xsThis, NULL);
-		xs_listener_destructor_(listener);
+		if (listener) {
+			xsForget(listener->obj);
+			xsmcSetHostData(xsThis, NULL);
+			xs_listener_destructor_(listener);
+		}
 		xsThrow(xsException);
 	}
 }


### PR DESCRIPTION
Moddable: 9.5.0
Platform: Linux and Mac

On Linux and Mac (not Windows) simulators, `xs_listener_constructor` calls `xsRemember` then, on bind/listen failure, frees the host data without `xsForget`. That leaves a dangling remembered root; after repeated failures and GC the VM can abort. 

The following will reproduce the failure:
- [main.js](https://github.com/user-attachments/files/32150992/main.js)
- [manifest.json](https://github.com/user-attachments/files/32150993/manifest.json)

Note: I do not currently have a working Mac  setup, so I've only verified the Linux patch.