### PR TITLE
WebSocketClient masking issues (on TCP split frames and control frames)

### DIFF
--- a/examples/io/tcp/websocketclient/websocketclient.js
+++ b/examples/io/tcp/websocketclient/websocketclient.js
@@ -237,18 +237,16 @@ class WebSocketClient {
 		if (options.mask) {
 			const mask = options.mask;
 			Logical.xor(data, mask, count);
-			if (this.#data) {
-				switch (count & 3) {
-					case 1:
-						options.mask = Uint8Array.of(mask[1], mask[2], mask[3], mask[0]);
-						break;
-					case 2:
-						options.mask = Uint8Array.of(mask[2], mask[3], mask[0], mask[1]);
-						break;
-					case 3:
-						options.mask = Uint8Array.of(mask[3], mask[0], mask[1], mask[2]);
-						break;
-				}
+			switch (count & 3) {
+				case 1:
+					options.mask = Uint8Array.of(mask[1], mask[2], mask[3], mask[0]);
+					break;
+				case 2:
+					options.mask = Uint8Array.of(mask[2], mask[3], mask[0], mask[1]);
+					break;
+				case 3:
+					options.mask = Uint8Array.of(mask[3], mask[0], mask[1], mask[2]);
+					break;
 			}
 		}
 
@@ -405,8 +403,12 @@ class WebSocketClient {
 							options.control.position = 0;
 						}
 						const control = options.control;
+						const mask = options.mask;
 						while (readable && (control.position < options.length)) {
-							control[control.position++] = this.#socket.read();
+							let byte = this.#socket.read();
+							if (mask)
+								byte ^= mask[control.position & 3];
+							control[control.position++] = byte;
 							readable--;
 						}
 						if (control.position !== options.length)
@@ -458,6 +460,7 @@ class WebSocketClient {
 						delete options.tag;
 						delete options.control;
 						delete options.length;
+						delete options.mask;
 						continue;
 					}
 


### PR DESCRIPTION
Moddable: 9.5.0
Platform: all (verified only on Linux simulator and ESP32)

In `embedded:network/websocket/client`, I hit two masking bugs:

1. When a masked data frame is split across TCP reads, `read()` unmasks the first chunk but skips mask rotation when that read drains `#data` (even though more of the same frame remains).
2. Control-frame payloads (close/ping) are read without unmasking, so close codes delivered to `onControl` are garbage.

The following will reproduce the failure:
- [main.js](https://github.com/user-attachments/files/32151305/main.js)
- [manifest.json](https://github.com/user-attachments/files/32151306/manifest.json)
