### PR TITLE
Update for embedded_network typings

### DIFF
--- a/examples/manifest_typings.json
+++ b/examples/manifest_typings.json
@@ -42,8 +42,17 @@
 		"embedded:io/socket/*": [
 			"$(TYPINGS)/embedded_io/socket/*"
 		],
+		"embedded:io/socket/tcp/*": [
+			"$(TYPINGS)/embedded_io/socket/tcp/*"
+		],
 		"embedded:network/http/*": [
 			"$(TYPINGS)/embedded_network/http/*"
+		],
+		"embedded:network/http/server/route/*": [
+			"$(TYPINGS)/embedded_network/http/server/route/*"
+		],
+		"embedded:network/http/server/route/ws/*": [
+			"$(TYPINGS)/embedded_network/http/server/route/ws/*"
 		],
 		"embedded:network/mqtt/*": [
 			"$(TYPINGS)/embedded_network/mqtt/*"

--- a/typings/embedded_network/dns/resolver/udp.d.ts
+++ b/typings/embedded_network/dns/resolver/udp.d.ts
@@ -22,15 +22,14 @@ declare module "embedded:network/dns/resolver/udp" {
 
   interface Options {
     host: string
-    onResolved: ((host:string, address:any) => null)
-    onError: ((host:string) => null)
+    onResolved: ((host: string, address: any) => void)
+    onError: ((host: string) => void)
   }
 
   class Resolver {
     constructor(options: Record<string, any>)
     close(): void
     resolve(options: Options): void
-
   }
   interface Resolver extends Disposable {}
 

--- a/typings/embedded_network/http/server.d.ts
+++ b/typings/embedded_network/http/server.d.ts
@@ -40,7 +40,7 @@ declare module "embedded:network/http/server" {
         onResponse?(this: HTTPConnection, response: HTTPResponse): void;
         onWritable?(this: HTTPConnection, count: number): void;
         onDone?(this: HTTPConnection): void;
-        onError?(this: HTTPConnection): void;
+        onError?(this: HTTPConnection, error: string): void;
     }
 
     export interface HTTPConnection extends Disposable {
@@ -52,12 +52,15 @@ declare module "embedded:network/http/server" {
         write(bytes?: ByteBuffer): number;
         route: HTTPConnectionHandlers;
         format: "buffer";
+        protocol?: string;
     }
 
     export interface HTTPServerOptions {
-        io: typeof Listener;
+        socket: { io: typeof Listener } & Record<string, any>;
         port?: number;
-        onConnect(this: HTTPServer, connection: HTTPConnection): void;
+        keepAlive?: number;
+        onConnect?(this: HTTPServer, connection: HTTPConnection): void;
+        onRoute?(this: HTTPServer, request: HTTPRequest): any;
     }
 
     class HTTPServer {

--- a/typings/embedded_network/http/server/route/static.d.ts
+++ b/typings/embedded_network/http/server/route/static.d.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Tools.
+ *
+ *   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Tools is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare module "embedded:network/http/server/route/static" {
+    import type { HTTPConnectionHandlers } from "embedded:network/http/server";
+
+    export interface StaticRoute extends HTTPConnectionHandlers {
+        data: ByteBuffer | string;
+        contentType?: string;
+        headers?: Map<string, string | number>;
+        status?: number;
+    }
+
+    const route: StaticRoute;
+    export default route;
+}

--- a/typings/embedded_network/http/server/route/ws/handshake.d.ts
+++ b/typings/embedded_network/http/server/route/ws/handshake.d.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Tools.
+ *
+ *   The Moddable SDK Tools is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Tools is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with the Moddable SDK Tools.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare module "embedded:network/http/server/route/ws/handshake" {
+    import type { HTTPConnectionHandlers } from "embedded:network/http/server";
+
+    const route: HTTPConnectionHandlers;
+    export default route;
+}

--- a/typings/embedded_network/websocket/client.d.ts
+++ b/typings/embedded_network/websocket/client.d.ts
@@ -18,10 +18,13 @@
 *
 */
 
-// websocketclient.d.ts
+// websocket/client.d.ts
 
 declare module "embedded:network/websocket/client" {
-  interface WebSocketClientOptions {
+  import type TCP from "embedded:io/socket/tcp";
+  import type TLSSocket from "embedded:io/socket/tcp/tls";
+
+  export interface WebSocketClientOptions {
     onReadable?: (this: WebSocketClient, count: number, options: { more: boolean; binary: boolean }) => void;
     onWritable?: (this: WebSocketClient, count: number) => void;
     onControl?: (this: WebSocketClient, opcode: number, data: ArrayBuffer) => void;
@@ -29,23 +32,17 @@ declare module "embedded:network/websocket/client" {
     onError?: (this: WebSocketClient) => void;
     format?: "buffer" | "number";
     target?: any;
-    attach?: {
-      constructor: new (options: any) => any;
-    };
+    attach?: TCP | TLSSocket;
     host?: string;
     path?: string;
     port?: number;
     protocol?: string;
     headers?: Map<string, string>;
-    dns?: {
-      io: new (options: any) => any;
-    };
-    socket?: {
-      io: new (options: any) => any;
-    };
+    dns?: { io: new (options: any) => any } & Record<string, any>;
+    socket?: { io: new (options: any) => any } & Record<string, any>;
   }
 
-  interface WebSocketWriteOptions {
+  export interface WebSocketWriteOptions {
     opcode?: number;
     binary?: boolean;
     more?: boolean;

--- a/typings/embedded_provider/builtin.d.ts
+++ b/typings/embedded_provider/builtin.d.ts
@@ -30,6 +30,10 @@ declare module "embedded:provider/builtin" {
   import SPI from "embedded:io/spi";
   import Serial from "embedded:io/serial";
   import type { PinSpecifier } from "embedded:io/_common";
+  import type Listener from "embedded:io/socket/listener";
+  import type HTTPServer from "embedded:network/http/server";
+  import type WebSocketClient from "embedded:network/websocket/client";
+
   const device: {
     io: {
       Digital: typeof Digital;
@@ -52,6 +56,27 @@ declare module "embedded:provider/builtin" {
     SPI: { default: ConstructorParameters<typeof SPI>[0] };
     Serial: { default: ConstructorParameters<typeof Serial>[0] };
     pin: { [name: string]: PinSpecifier };
+    network: {
+      dns: {
+        resolver: Record<string, any>;
+      };
+      http: {
+        server: {
+          io: typeof HTTPServer;
+          socket: { io: typeof Listener } & Record<string, any>;
+        };
+      };
+      ws: {
+        io: typeof WebSocketClient;
+        dns: { io: new (options: any) => any } & Record<string, any>;
+        socket: { io: new (options: any) => any } & Record<string, any>;
+      };
+      wss: {
+        io: typeof WebSocketClient;
+        dns: { io: new (options: any) => any } & Record<string, any>;
+        socket: { io: new (options: any) => any } & Record<string, any>;
+      };
+    };
   };
   export default device;
 }


### PR DESCRIPTION
Moddable: 9.5.0
Platform: All (TypeScript typings)

A collection of `embedded_network` typings.  My prior PR (now closed) tried to be a broad, strict platform for `io`, but it came with a lot of complexity (I'm guessing that is why it never merged).  I finally updated my environment from 5.6.0 to 9.5.0 (!) and started anew on this.  I focused only on the types I need, and didn't try to hard type all properties (e.g. using `any` similar to how the latest `io` typings are defined). Hopefully this version is easier to digest! ;-)

Note: the `udp.d.ts` file optional ... it just caught my attention that the prototypes were using `null` instead of what most of your typings use (`void`).  Take it or leave it...!